### PR TITLE
Set UseDefaultCredentials to true on WebClient for web proxy authentication

### DIFF
--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -17,10 +17,10 @@
 </section>
 <div class="nuget-badge">
     <p>
-        <code><span>C:\&gt;</span> @@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient -property @@{UseDefaultCredentials=$true}).DownloadString('https://chocolatey.org/install.ps1'))" &amp;&amp; SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin</code>
+        <code><span>C:\&gt;</span> @@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$wc=new-object net.webclient;$wc.Proxy.Credentials=[net.credentialcache]::DefaultCredentials;iex ($wc.DownloadString('https://chocolatey.org/install.ps1'))" &amp;&amp; SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin</code>
     </p>
     <p>
-        <code><span>PS:\&gt;</span>iex ((new-object net.webclient -property @@{UseDefaultCredentials=$true}).DownloadString('https://chocolatey.org/install.ps1'))</code>
+        <code><span>PS:\&gt;</span>$wc=new-object net.webclient;$wc.Proxy.Credentials=[net.credentialcache]::DefaultCredentials;iex ($wc.DownloadString('https://chocolatey.org/install.ps1'))</code>
     </p>
 </div>
 

--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -17,10 +17,10 @@
 </section>
 <div class="nuget-badge">
     <p>
-        <code><span>C:\&gt;</span> @@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" &amp;&amp; SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin</code>
+        <code><span>C:\&gt;</span> @@powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient -property @@{UseDefaultCredentials=$true}).DownloadString('https://chocolatey.org/install.ps1'))" &amp;&amp; SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin</code>
     </p>
     <p>
-        <code><span>PS:\&gt;</span>iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))</code>
+        <code><span>PS:\&gt;</span>iex ((new-object net.webclient -property @@{UseDefaultCredentials=$true}).DownloadString('https://chocolatey.org/install.ps1'))</code>
     </p>
 </div>
 


### PR DESCRIPTION
Setting this property to true (default is false unfortunately) will use the default credentials to authenticate with the web proxy in case one is present. For corporate users behind proxies this will enhance chances that chocolatey bootstrapping will work out of the box (copy from home page and run in cmd.exe or PowerShell). Hope I got the Razor markup right, checked it with a new MVC project in Visual Studio and it looked good, but wasn't able to run the real website solution for some reason.