### PR TITLE
Adding Disqus Notification Emails

### DIFF
--- a/chocolatey/Website/App_Start/Routes.cs
+++ b/chocolatey/Website/App_Start/Routes.cs
@@ -41,6 +41,11 @@ namespace NuGetGallery
                 "packages",
                 MVC.Packages.ListPackages());
 
+            var packageNotifyComment = routes.MapRoute(
+                RouteName.NotifyComment,
+                "packages/{packageId}/notify-comment",
+                new { controller = MVC.Packages.Name, action = "NotifyMaintainersOfAddedComment" });
+
             var uploadPackageRoute = routes.MapRoute(
                 RouteName.UploadPackage,
                 "packages/upload",

--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -703,6 +703,22 @@ namespace NuGetGallery
             return RedirectToAction(MVC.Packages.UploadPackage());
         }
 
+        [HttpPost, ValidateSpamPrevention]
+        public virtual ActionResult NotifyMaintainersOfAddedComment(string packageId, CommentViewModel commentViewModel)
+        {
+            var package = packageSvc.FindPackageRegistrationById(packageId);
+            if (package == null)
+            {
+                return PackageNotFound(packageId);
+            }
+
+            var packageUrl = EnsureTrailingSlash(Configuration.GetSiteRoot(useHttps: false)) + RemoveStartingSlash(Url.Package(package));
+
+            messageService.SendCommentNotificationToMaintainers(package, commentViewModel, packageUrl);
+
+            return new HttpStatusCodeResult(200);
+        }
+
         // this methods exist to make unit testing easier
         protected internal virtual IIdentity GetIdentity()
         {

--- a/chocolatey/Website/RouteNames.cs
+++ b/chocolatey/Website/RouteNames.cs
@@ -18,6 +18,7 @@
         public const string ListPackages = "ListPackages";
         public const string Authentication = "SignIn";
         public const string UploadPackage = "UploadPackage";
+        public const string NotifyComment = "NotifyComment";
         public const string ManagePackageOwners = "ManagePackageOwners";
         public const string PackageVersionAction = "PackageVersionAction";
         public const string PackageOwnerConfirmation = "PackageOwnerConfirmation";

--- a/chocolatey/Website/Services/IMessageService.cs
+++ b/chocolatey/Website/Services/IMessageService.cs
@@ -5,6 +5,7 @@ namespace NuGetGallery
     public interface IMessageService
     {
         void SendContactOwnersMessage(MailAddress fromAddress, PackageRegistration packageRegistration, string message, string emailSettingsUrl,string packageUrl, bool copySender);
+        void SendCommentNotificationToMaintainers(PackageRegistration packageRegistration, CommentViewModel comment, string packageUrl);
         void ReportAbuse(MailAddress fromAddress, Package package, string message, string packageUrl, bool copySender);
         void ContactSiteAdmins(MailAddress fromAddress, Package package, string message, string packageUrl, bool copySender);
         void SendNewAccountEmail(MailAddress toAddress, string confirmationUrl);

--- a/chocolatey/Website/Services/MessageService.cs
+++ b/chocolatey/Website/Services/MessageService.cs
@@ -150,6 +150,42 @@ Package Url: {6}
             }
         }
 
+        public void SendCommentNotificationToMaintainers(PackageRegistration packageRegistration, CommentViewModel comment, string packageUrl)
+        {
+            string body = @"Comment: {0}
+
+This comment has been added to the disqus forum thread for {1}. 
+It may not show up immediately if it is subject to moderation but we wanted you to know about it.
+
+Package Url: {2}
+Comment Url: {3}
+";
+            string subject = "[{0}] New disqus comment for maintainers of '{1}'";
+            string disqusCommentUrl = string.Format("{0}#comment-{1}", packageUrl, comment.Id);
+
+            body = String.Format(CultureInfo.CurrentCulture,
+                body,
+                comment.Text,
+				packageRegistration.Id,
+                packageUrl,
+                disqusCommentUrl);
+
+            subject = String.Format(CultureInfo.CurrentCulture, subject, settings.GalleryOwnerName, packageRegistration.Id);
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = new MailAddress(settings.GalleryOwnerEmail, settings.GalleryOwnerName);
+
+                AddOwnersToMailMessage(packageRegistration, mailMessage);
+                if (mailMessage.To.Any())
+                {
+                    SendMessage(mailMessage);
+                }
+            }
+        }
+
         private static void AddOwnersToMailMessage(PackageRegistration packageRegistration, MailMessage mailMessage)
         {
             foreach (var owner in packageRegistration.Owners.Where(o => o.EmailAllowed))

--- a/chocolatey/Website/ViewModels/CommentViewModel.cs
+++ b/chocolatey/Website/ViewModels/CommentViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace NuGetGallery
+{
+    public class CommentViewModel
+    {
+        public string Id { get; set; }
+
+        public string Text { get; set; }
+    }
+}

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -487,6 +487,7 @@
     @{
         var disqusUrl = "http://" + Request.Url.Host + @Url.Package(Model.Id);
         string disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
+        var commentPostUrl = disqusUrl + "/notify-comment";
     }
     <div id="disqus_thread">
     </div>
@@ -498,9 +499,15 @@
         var commentItem;
         function disqus_config() {
             this.callbacks.onNewComment = [function (comment) {
-                //comment.id comment.text
-                //commentItem = comment;
-                //console.log('New comment: ' + comment.text);
+                console.log('New Comment Id: ' + comment.id);
+                console.log('New Comment Text: ' + comment.text);
+
+                var commentViewModel = { Id: comment.id, Text: comment.text };
+
+                // take the data and post it via json
+                $.post('@commentPostUrl', commentViewModel, function (data) {
+                    // At the minute, it is fire and forget
+                });
             } ];
         }
 

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1155,6 +1155,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="UrlExtensions.cs" />
+    <Compile Include="ViewModels\CommentViewModel.cs" />
     <Compile Include="ViewModels\ContactOwnersViewModel.cs" />
     <Compile Include="ViewModels\DisplayPackageViewModel.cs" />
     <Compile Include="ViewModels\EditProfileViewModel.cs" />


### PR DESCRIPTION
Attempts to implement requirements for #27
- Added new MessageService method to construct email to current maintainers
- Added same method signature to interface
- Created new ViewModel for sending id and text of comment from the client
- Added new PackagesController method for accepting post from client when new Disqus comment is added
- Added new Route to handle mapping to new controller method