### PR TITLE
Made Disqus Shortname Configurable

### DIFF
--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -486,12 +486,13 @@
     </p>
     @{
         var disqusUrl = "http://" + Request.Url.Host + @Url.Package(Model.Id);
+        string disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
     }
     <div id="disqus_thread">
     </div>
 
     <script type="text/javascript">
-        var disqus_shortname = 'chocolatey';
+        var disqus_shortname = '@disqusShortname';
 
         var disqus_url = '@disqusUrl';
         var commentItem;

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -37,6 +37,7 @@
     <add key="Gallery:ConfirmEmailAddresses" value="true" />
     <add key="Gallery:PackageFileTextExtensions" value="ps1,psm1,txt,md,cmd,config,bat,sh,json,js,xml,ini,iss,ahk,au3,sql" />
     <add key="ForceSSL" value="true" />
+    <add key="DisqusShortname" value="chocolatey-local"/>
   </appSettings>
   <connectionStrings>
     <add name="NuGetGallery" connectionString="Data Source=(local)\SQLExpress;Initial Catalog=NuGetGallery;Integrated Security=SSPI" providerName="System.Data.SqlClient" />


### PR DESCRIPTION
- In order to allow configuration of Disqus Shortname, i.e. change it
for multiple deployment environments, moved it into the web.config file.
- We should then be able to update the web.config file settings based on
whether we are running locally, i.e. the default, or on AppHarbor, or on
chocolatey.org