### PR TITLE
Changed Comment Post Url

### DIFF
--- a/chocolatey/Website/Services/MessageService.cs
+++ b/chocolatey/Website/Services/MessageService.cs
@@ -161,10 +161,11 @@ Package comments: [http://chocolatey.org/packages/{2}#disqus](http://chocolatey.
             string body = @"Comment: {0}
 
 This comment has been added to the disqus forum thread for {1}. 
-It may not show up immediately if it is subject to moderation but we wanted you to know about it.
 
 Package Url: {2}
 Comment Url: {3}
+
+{4}
 ";
             string subject = "[{0}] New disqus comment for maintainers of '{1}'";
             string disqusCommentUrl = string.Format("{0}#comment-{1}", packageUrl, comment.Id);
@@ -174,7 +175,8 @@ Comment Url: {3}
                 comment.Text,
 				packageRegistration.Id,
                 packageUrl,
-                disqusCommentUrl);
+                disqusCommentUrl,
+                GetDisqusInformationMessage());
 
             subject = String.Format(CultureInfo.CurrentCulture, subject, settings.GalleryOwnerName, packageRegistration.Id);
 
@@ -393,6 +395,18 @@ Maintainer(s): {2}
                     SendMessage(mailMessage);
                 }
             }
+        }
+
+        private string GetDisqusInformationMessage()
+        {
+            return @"
+### Information for Maintainers
+
+ * Disqus comments can be moderated.  As a result, you may not see the above comment on the package page until the comment is moderated.
+ * If the comment seems legitimate, i.e. not a spam comment, you can take action straight away.
+ * You will not be able to reply to the Disqus Comment until it is moderated.
+ * You are encouraged to reply directly to the Disqus Comment when required action is taken.
+";
         }
 
         private string GetInformationForMaintainers(Package package, string comments)

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -476,18 +476,20 @@
                 google group</a>.</li>
             <li>This discussion will carry over multiple versions. If you have a comment about a
                 particular version, please note that in your comments.</li>
-            <li>This is not a substitute for contacting package maintainers. Please use the link
+            <li>The maintainers of this Chocolatey Package will be notified about new comments that are posted to this Disqus thread, however, it is NOT a guarantee that you
+                will get a response.  If you do not hear back from the maintainers after posting a message below, please follow up by using the link
                 on the left side of this page or follow this link to <a href="@Url.Action(MVC.Packages.ContactOwners(Model.Id))">
-                contact maintainers</a>.</li>
+                contact maintainers</a>.  If you still hear nothing back, please follow the <a href="https://github.com/chocolatey/chocolatey/wiki/PackageTriageProcess">package triage process</a>.</li>
             <li>Tell us what you love about the package or @Model.Title, or tell us what needs improvement.</li>
-            <li>Share your experiences with the package, or extra configuration or got yas that
+            <li>Share your experiences with the package, or extra configuration or gotchas that
                 you've found.</li>
         </ul>
     </p>
     @{
         var disqusUrl = "http://" + Request.Url.Host + @Url.Package(Model.Id);
-        string disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
-        var commentPostUrl = Request.Url + "/notify-comment";
+        var disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
+        bool forceSsl = Convert.ToBoolean(System.Configuration.ConfigurationManager.AppSettings["ForceSSL"]);
+        var commentPostUrl = (forceSsl ? "https" : Request.Url.Scheme) + "://" + Request.Url.Authority + @Url.Package(Model.Id) + "/notify-comment";
     }
 	<a name="disqus"></a>
     <div id="disqus_thread">
@@ -500,9 +502,6 @@
         var commentItem;
         function disqus_config() {
             this.callbacks.onNewComment = [function (comment) {
-                console.log('New Comment Id: ' + comment.id);
-                console.log('New Comment Text: ' + comment.text);
-
                 var commentViewModel = { Id: comment.id, Text: comment.text };
 
                 // take the data and post it via json

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -36,7 +36,7 @@
     <add key="Gallery:SmtpEnableSsl" value="false" />
     <add key="Gallery:ConfirmEmailAddresses" value="true" />
     <add key="Gallery:PackageFileTextExtensions" value="ps1,psm1,txt,md,cmd,config,bat,sh,json,js,xml,ini,iss,ahk,au3,sql" />
-    <add key="ForceSSL" value="true" />
+    <add key="ForceSSL" value="false" />
     <add key="DisqusShortname" value="chocolatey-local"/>
   </appSettings>
   <connectionStrings>


### PR DESCRIPTION
- Changed default value of ForceSSL to be false (so that it will work
locally)
- Updated notes above Disqus thread to indicate new notifications
- Following discussion with Rob, built up comment Post Url in a way that
it will hopefully work locally, and on staging and production