### PR TITLE
(GH-151) Moderator can add maintainer directly

### DIFF
--- a/chocolatey/Website/Controllers/JsonApiController.cs
+++ b/chocolatey/Website/Controllers/JsonApiController.cs
@@ -1,0 +1,105 @@
+﻿using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using MvcHaack.Ajax;
+
+namespace NuGetGallery
+{
+    public partial class JsonApiController : JsonController
+    {
+        IPackageService packageSvc;
+        IUserService userSvc;
+        IEntityRepository<PackageOwnerRequest> packageOwnerRequestRepository;
+        IMessageService messageSvc;
+
+        public JsonApiController(IPackageService packageSvc, IUserService userSvc, IEntityRepository<PackageOwnerRequest> packageOwnerRequestRepository, IMessageService messageService)
+        {
+            this.packageSvc = packageSvc;
+            this.userSvc = userSvc;
+            this.packageOwnerRequestRepository = packageOwnerRequestRepository;
+            this.messageSvc = messageService;
+        }
+
+        [Authorize]
+        public virtual object GetPackageOwners(string id, string version)
+        {
+            var package = packageSvc.FindPackageByIdAndVersion(id, version);
+            if (package == null)
+            {
+                return new { message = "Package not found" };
+            }
+            if (!package.IsOwner(HttpContext.User))
+            {
+                return new HttpStatusCodeResult(401, "Unauthorized");
+            }
+
+            var owners = from u in package.PackageRegistration.Owners
+                         select new OwnerModel
+                         {
+                             name = u.Username,
+                             current = u.Username == HttpContext.User.Identity.Name,
+                             pending = false
+                         };
+
+            var pending = from u in packageOwnerRequestRepository.GetAll()
+                          where u.PackageRegistrationKey == package.PackageRegistration.Key
+                          select new OwnerModel { name = u.NewOwner.Username, current = false, pending = true };
+
+            return owners.Union(pending);
+        }
+
+        public object AddPackageOwner(string id, string username)
+        {
+            var package = packageSvc.FindPackageRegistrationById(id);
+            if (package == null)
+            {
+                return new { success = false, message = "Package not found" };
+            }
+            if (!package.IsOwner(HttpContext.User))
+            {
+                return new { success = false, message = "You are not the package maintainer." };
+            }
+            var user = userSvc.FindByUsername(username);
+            if (user == null)
+            {
+                return new { success = false, message = "Maintainer not found" };
+            }
+
+            var currentUser = userSvc.FindByUsername(HttpContext.User.Identity.Name);
+            var ownerRequest = packageSvc.CreatePackageOwnerRequest(package, currentUser, user);
+
+            var confirmationUrl = Url.ConfirmationUrl(MVC.Packages.ConfirmOwner().AddRouteValue("id", package.Id), user.Username, ownerRequest.ConfirmationCode, Request.Url.Scheme);
+            messageSvc.SendPackageOwnerRequest(currentUser, user, package, confirmationUrl);
+
+            return new { success = true, name = user.Username, pending = true };
+        }
+
+        public object RemovePackageOwner(string id, string username)
+        {
+            var package = packageSvc.FindPackageRegistrationById(id);
+            if (package == null)
+            {
+                return new { success = false, message = "Package not found" };
+            }
+            if (!package.IsOwner(HttpContext.User))
+            {
+                return new { success = false, message = "You are not the package maintainer." };
+            }
+            var user = userSvc.FindByUsername(username);
+            if (user == null)
+            {
+                return new { success = false, message = "Maintainer not found" };
+            }
+
+            packageSvc.RemovePackageOwner(package, user);
+            return new { success = true };
+        }
+
+        public class OwnerModel
+        {
+            public string name { get; set; }
+            public bool current { get; set; }
+            public bool pending { get; set; }
+        }
+    }
+}

--- a/chocolatey/Website/Services/IMessageService.cs
+++ b/chocolatey/Website/Services/IMessageService.cs
@@ -13,6 +13,7 @@ namespace NuGetGallery
         void SendPasswordResetInstructions(User user, string resetPasswordUrl);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
         void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl);
+        void SendPackageOwnerConfirmation(User fromUser, User toUser, PackageRegistration package);
         void SendPackageModerationEmail(Package package,string comments);
     }
 }

--- a/chocolatey/Website/Services/MessageService.cs
+++ b/chocolatey/Website/Services/MessageService.cs
@@ -359,6 +359,37 @@ The {3} Team";
             }
         }
 
+        public void SendPackageOwnerConfirmation(User fromUser, User toUser, PackageRegistration package)
+        {
+            if (!toUser.EmailAllowed)
+            {
+                return;
+            }
+            var packageUrl = string.Format("{0}packages/{1}", EnsureTrailingSlash(Configuration.ReadAppSettings("SiteRoot")), package.Id);
+          
+
+            string subject = "[{0}] The user '{1}' has added you as a maintainer of the package '{2}'.";
+
+            string body = @"The user '{0}' has added you as a maintainer of the package '{1}'. 
+
+Package Url: {2}
+
+Thanks,
+The {3} Team";
+
+            body = String.Format(CultureInfo.CurrentCulture, body, fromUser.Username, package.Id, packageUrl, settings.GalleryOwnerName);
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = String.Format(CultureInfo.CurrentCulture, subject, settings.GalleryOwnerName, fromUser.Username, package.Id);
+                mailMessage.Body = body;
+                mailMessage.From = fromUser.ToMailAddress();
+
+                mailMessage.To.Add(toUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
         public void SendPackageModerationEmail(Package package,string comments)
         {
             string subject = "[{0}] Moderation for '{1}' v{2}";

--- a/chocolatey/Website/Views/Packages/ManagePackageOwners.cshtml
+++ b/chocolatey/Website/Views/Packages/ManagePackageOwners.cshtml
@@ -15,12 +15,13 @@
         <em data-bind="visible: pending">(pending approval)</em> 
         @if (moderator)
         {
-            <a href="#" title="Remove as maintainer of of @Model.Title" data-bind="click: remove">Remove</a>
+            <a href="#" title="Remove as maintainer of @Model.Title" data-bind="click: remove">Remove</a>
         }
         else
         { 
-            <a href="#" title="Remove as maintainer of of @Model.Title" data-bind="visible: !current, click: remove">Remove</a>
-        }        
+            <a href="#" title="Remove as maintainer of @Model.Title" data-bind="visible: !current, click: remove">Remove</a>
+        }  
+        <input type="checkbox" data-bind="visible: false, checked: addDirectly" />
     </li>
 </ul>
 
@@ -32,7 +33,8 @@
     NOTE: All package maintainers have full control over their packages,
     including the ability to remove other users as maintainers.
 </p>
-@using (Html.BeginForm()) {
+@using (Html.BeginForm())
+{
     <fieldset class="form">
         <legend>Add Maintainer</legend>
         <div class="form-field">
@@ -40,7 +42,12 @@
             <input type="text" name="newOwnerUserName" data-bind="value: newOwner().name" />
         </div>
         <input type="submit" value="Add" title="Add the user as a maintainer to @Model.Title" data-bind="click: addOwner" />
-    </fieldset>
+        @if (moderator)
+        {
+            <input type="checkbox" name="newOwnerAddDirectly" data-bind="checked: newOwner().addDirectly" />
+            <label for="newOwnerAddDirectly">Add Without Pending</label>
+        }
+     </fieldset>
 }
 
 
@@ -60,6 +67,7 @@
             owners: ko.observableArray([]),
             newOwner: ko.observable(new Owner(null)),
             message: ko.observable(''),
+            
             addOwner: function () {
                 var ownerInputModel = viewModel.newOwner().toJS();
                 ownerInputModel.id = viewModel.package.id;
@@ -68,7 +76,7 @@
                     .done(function (data) {
                         if (data.success) {
                             viewModel.newOwner().name(data.name);
-                            viewModel.newOwner().pending(true);
+                            viewModel.newOwner().pending(data.pending);
                             viewModel.owners.push(viewModel.newOwner());
                             viewModel.newOwner(new Owner(null));
                         }
@@ -97,7 +105,7 @@
         // Load initial maintainers (owners).
         $mvc.JsonApi.GetPackageOwners(viewModel.package)
         .done(function (data) {
-            viewModel.owners($.map(data, function (item) { return new Owner(item) }));
+            viewModel.owners($.map(data, function (item) { return new Owner(item); }));
         })
         .fail(failHandler);
 
@@ -109,11 +117,12 @@
             this.name = ko.observable(item.name);
             this.pending = ko.observable(item.pending);
             this.current = item.current;
+            this.addDirectly = ko.observable(false);
             this.remove = function () {
                 viewModel.removeOwner(this);
             };
             this.toJS = function () {
-                return { username: this.name() };
+                return { username: this.name(), addDirectly: this.addDirectly() };
             };
         }
     });

--- a/chocolatey/Website/Views/Packages/ManagePackageOwners.cshtml
+++ b/chocolatey/Website/Views/Packages/ManagePackageOwners.cshtml
@@ -1,6 +1,7 @@
 ﻿@model ManagePackageOwnersViewModel
 @{
     ViewBag.Tab = "Packages";
+    var moderator = User != null && User.IsInRole(Constants.AdminRoleName);
 }
 
 
@@ -12,7 +13,14 @@
     <li>
         <span data-bind="text: name"></span> <em data-bind="visible: current">(that&#8217;s you!)</em> 
         <em data-bind="visible: pending">(pending approval)</em> 
-        <a href="#" title="Remove as maintainer of of @Model.Title" data-bind="visible: !current, click: remove">Remove</a>
+        @if (moderator)
+        {
+            <a href="#" title="Remove as maintainer of of @Model.Title" data-bind="click: remove">Remove</a>
+        }
+        else
+        { 
+            <a href="#" title="Remove as maintainer of of @Model.Title" data-bind="visible: !current, click: remove">Remove</a>
+        }        
     </li>
 </ul>
 

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -640,9 +640,6 @@
       <Link>AuthenticationController.generated.cs</Link>
       <DependentUpon>T4MVC.tt</DependentUpon>
     </Compile>
-    <Compile Include="..\..\nugetgallery\Website\Controllers\JsonApiController.cs">
-      <Link>Controllers\JsonApiController.cs</Link>
-    </Compile>
     <Compile Include="..\..\nugetgallery\Website\DynamicData\Content\GridViewPager.ascx.cs">
       <Link>DynamicData\Content\GridViewPager.ascx.cs</Link>
       <DependentUpon>GridViewPager.ascx</DependentUpon>
@@ -1079,6 +1076,7 @@
     <Compile Include="App_Start\IConfiguration.cs" />
     <Compile Include="App_Start\PackageStoreType.cs" />
     <Compile Include="App_Start\Routes.cs" />
+    <Compile Include="Controllers\JsonApiController.cs" />
     <Compile Include="DataServices\PackageExtensions.cs" />
     <Compile Include="Infrastructure\Lucene\LuceneIndexingService.cs" />
     <Compile Include="Infrastructure\SimpleInjectorContainerResolutionBehavior.cs" />


### PR DESCRIPTION
Allow maintainer the ability to add a maintainer without need for
confirmation. This will assist when adding the chocolatey user as a
maintainer. That way there is only a confirmation email instead of an
email that requires action.

This also allows a moderator to remove themselves from being a package
maintainer.