### PR TITLE
oData Feed for Submitted Packages

### DIFF
--- a/chocolatey/Website/App_Start/Routes.cs
+++ b/chocolatey/Website/App_Start/Routes.cs
@@ -263,6 +263,11 @@ namespace NuGetGallery
                 typeof(V2CuratedFeed));
 
             routes.MapServiceRoute(
+                RouteName.V2ApiSubmittedFeed, 
+                "api/v2/submitted", 
+                typeof(V2SubmittedFeed));
+
+            routes.MapServiceRoute(
                 RouteName.V2ApiFeed,
                 "api/v2/",
                 typeof(V2Feed));

--- a/chocolatey/Website/DataServices/V2SubmittedFeed.svc
+++ b/chocolatey/Website/DataServices/V2SubmittedFeed.svc
@@ -1,0 +1,1 @@
+﻿<%@ ServiceHost Language="C#" Debug="true" Service="NuGetGallery.V2SubmittedFeed" CodeBehind="V2SubmittedFeed.svc.cs" %>

--- a/chocolatey/Website/DataServices/V2SubmittedFeed.svc.cs
+++ b/chocolatey/Website/DataServices/V2SubmittedFeed.svc.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+
+namespace NuGetGallery
+{
+    using System;
+    using System.Data.Entity;
+    using System.Data.Services;
+    using System.ServiceModel.Web;
+    using System.Web.Mvc;
+    using System.Web.Routing;
+
+    public class V2SubmittedFeed : FeedServiceBase<V2FeedPackage>
+    {
+        private const int FeedVersion = 2;
+        private readonly string submittedStatus = PackageStatusType.Submitted.GetDescriptionOrValue();
+
+        public V2SubmittedFeed()
+        {
+        }
+
+        public V2SubmittedFeed(IEntitiesContext entities, IEntityRepository<Package> repo, IConfiguration configuration, ISearchService searchSvc)
+            : base(entities, repo, configuration, searchSvc)
+        {
+        }
+
+        protected override FeedContext<V2FeedPackage> CreateDataSource()
+        {
+            return new FeedContext<V2FeedPackage>
+            {
+                Packages = PackageRepo.GetAll()
+                                .Where(p => p.StatusForDatabase == submittedStatus)
+                                .WithoutVersionSort()
+                                .ToV2FeedPackageQuery(GetSiteRoot())
+            };
+        }
+
+        public static void InitializeService(DataServiceConfiguration config)
+        {
+            InitializeServiceBase(config);
+        }
+
+        [WebGet]
+        public IQueryable<V2FeedPackage> Search(string searchTerm, string targetFramework, bool includePrerelease)
+        {
+            var packages = PackageRepo.GetAll()
+                .Where(p => p.StatusForDatabase == PackageStatusType.Submitted.GetDescriptionOrValue());
+            return SearchCore(packages, searchTerm, targetFramework, includePrerelease).ToV2FeedPackageQuery(GetSiteRoot());
+        }
+
+        [WebGet]
+        public IQueryable<V2FeedPackage> FindPackagesById(string id)
+        {
+            return PackageRepo.GetAll().Include(p => p.PackageRegistration)
+                                       .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase) && p.StatusForDatabase == submittedStatus)
+                                       .ToV2FeedPackageQuery(GetSiteRoot());
+        }
+
+        public override Uri GetReadStreamUri(object entity, DataServiceOperationContext operationContext)
+        {
+            var package = (V2FeedPackage)entity;
+            var urlHelper = new UrlHelper(new RequestContext(HttpContext, new RouteData()));
+
+            string url = urlHelper.PackageDownload(FeedVersion, package.Id, package.Version);
+
+            return new Uri(url, UriKind.Absolute);
+        }
+
+        private string GetSiteRoot()
+        {
+            return Configuration.GetSiteRoot(UseHttps());
+        }
+    }
+}

--- a/chocolatey/Website/RouteNames.cs
+++ b/chocolatey/Website/RouteNames.cs
@@ -5,6 +5,7 @@
         public const string V2ApiCuratedFeed = "V2ApiCuratedFeed";
         public const string V1ApiFeed = "V1ApiFeed";
         public const string V2ApiFeed = "V2ApiFeed";
+        public const string V2ApiSubmittedFeed = "V2ApiSubmittedFeed";
         public const string ApiFeed = "ApiFeed";
         public const string Account = "Account";
         public const string Profile = "Profile";

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1078,6 +1078,9 @@
     <Compile Include="App_Start\Routes.cs" />
     <Compile Include="Controllers\JsonApiController.cs" />
     <Compile Include="DataServices\PackageExtensions.cs" />
+    <Compile Include="DataServices\V2SubmittedFeed.svc.cs">
+      <DependentUpon>V2SubmittedFeed.svc</DependentUpon>
+    </Compile>
     <Compile Include="Infrastructure\Lucene\LuceneIndexingService.cs" />
     <Compile Include="Infrastructure\SimpleInjectorContainerResolutionBehavior.cs" />
     <Compile Include="App_Start\SimpleInjectorInitializer.cs" />
@@ -1362,6 +1365,7 @@
     <Content Include="Content\SyntaxHighlighter\shThemeMDUltra.css" />
     <Content Include="Content\SyntaxHighlighter\shThemeMidnight.css" />
     <Content Include="Content\SyntaxHighlighter\shThemeRDark.css" />
+    <Content Include="DataServices\V2SubmittedFeed.svc" />
     <Content Include="Errors\Error.html" />
     <Content Include="favicon.ico" />
     <Content Include="Install-LastPoshClient.ps1" />
@@ -1500,7 +1504,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Provide ability to query, via oData, only from the packages which are
currently in a submitted state.

Without this change, automated package moderation will not be able to
get started.

Closed #175