### PR TITLE
Remove mentioning of ProGet Chocolatey package

### DIFF
--- a/chocolatey/Website/Views/Documentation/HowToHostFeed.cshtml
+++ b/chocolatey/Website/Views/Documentation/HowToHostFeed.cshtml
@@ -11,7 +11,7 @@
 <p><strong>Alternative Hosting Options (that require less work/maintenance):</strong></p>
 <ul>
 <li><a href="https://www.myget.org/">MyGet</a> - MyGet has free public and paid for public/private cloud-hosting options if you don&#39;t want to handle all of the pain of setup and administration. MyGet offers some stellar options like multi-feed aggregation, mirroring, and source package build services!</li>
-<li><a href="http://inedo.com/proget/overview">ProGet</a> - ProGet gives you a ready to go On-Premise option (<a href="https://chocolatey.org/packages/proget">installable with Chocolatey!</a>).</li>
+<li><a href="http://inedo.com/proget/overview">ProGet</a> - ProGet gives you a ready to go On-Premise option.</li>
 <li><a href="http://www.jfrog.com/open-source/">Artifactory</a> - see <a href="http://www.jfrog.com/confluence/display/RTF/NuGet+Repositories">Artifactory NuGet Repositories</a> - not in the free version</li>
 <li><a href="https://www.jetbrains.com/teamcity/">TeamCity</a> has built-in Simple Server</li>
 <li><a href="https://books.sonatype.com/nexus-book/reference/nuget-nuget_proxy_repositories.html">Nexus</a> - Sonatype Nexus has a built-in simple server</li>


### PR DESCRIPTION
Remove mentioning of ProGet being able to be installed using Chocolatey, since that package is broken, Inedo admitted that they haven't touched it since ages and show no interested in fixing it (instead people should build their own scripts)
