### PR TITLE
(GH-493) View unlisted packages as a moderator

### DIFF
--- a/chocolatey/Website/ViewModels/ListPackageItemViewModel.cs
+++ b/chocolatey/Website/ViewModels/ListPackageItemViewModel.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+
+namespace NuGetGallery
+{
+    public class ListPackageItemViewModel : PackageViewModel
+    {
+        public ListPackageItemViewModel(Package package, bool needAuthors = true)
+            : base(package)
+        {
+            Tags = package.Tags != null ? package.Tags.Trim().Split(' ') : null;
+
+            if (needAuthors)
+            {
+                Authors = package.Authors;
+            }
+
+            Owners = package.PackageRegistration.Owners;
+        }
+        public IEnumerable<PackageAuthor> Authors { get; set; }
+        public ICollection<User> Owners { get; set; }
+        public IEnumerable<string> Tags { get; set; }
+        public bool IsOwner(IPrincipal user)
+        {
+            if (user == null || user.Identity == null)
+            {
+                return false;
+            }
+            return user.IsInRole(Constants.AdminRoleName) || Owners.Any(u => u.Username == user.Identity.Name);
+        }
+        public bool UseVersion
+        {
+            get
+            {
+                // only show the version when we'll end up listing the package more than once. This would happen when the latest version is not the same as the latest stable version.
+                return !(LatestVersion && LatestStableVersion);
+            }
+        }
+    }
+}

--- a/chocolatey/Website/ViewModels/ListPackageItemViewModel.cs
+++ b/chocolatey/Website/ViewModels/ListPackageItemViewModel.cs
@@ -27,7 +27,7 @@ namespace NuGetGallery
             {
                 return false;
             }
-            return user.IsInRole(Constants.AdminRoleName) || Owners.Any(u => u.Username == user.Identity.Name);
+            return user.IsAdmin() || user.IsModerator() || Owners.Any(u => u.Username == user.Identity.Name);
         }
         public bool UseVersion
         {

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -791,6 +791,7 @@
     <Compile Include="Services\UploadFileService.cs" />
     <Compile Include="Services\UserService.cs" />
     <Compile Include="ViewModels\ContactUsViewModel.cs" />
+    <Compile Include="ViewModels\ListPackageItemViewModel.cs" />
     <Compile Include="ViewModels\MarkdownPostViewModel.cs" />
     <Compile Include="ViewModels\PasswordChangeViewModel.cs" />
     <Compile Include="ViewModels\PasswordResetViewModel.cs" />
@@ -869,9 +870,6 @@
     </Compile>
     <Compile Include="..\..\nugetgallery\Website\ViewModels\ManagePackagesViewModel.cs">
       <Link>ViewModels\ManagePackagesViewModel.cs</Link>
-    </Compile>
-    <Compile Include="..\..\nugetgallery\Website\ViewModels\ListPackageItemViewModel.cs">
-      <Link>ViewModels\ListPackageItemViewModel.cs</Link>
     </Compile>
     <Compile Include="..\..\nugetgallery\Website\ViewModels\PasswordResetRequestViewModel.cs">
       <Link>ViewModels\PasswordResetRequestViewModel.cs</Link>


### PR DESCRIPTION
this PR fixes the issue mentioned on gitter that moderators can't see unlisted packages unless they also are the owners of that package.

The fix could instead be changed at the following location: https://github.com/chocolatey/chocolatey.org/blob/master/chocolatey/Website/Views/Packages/_ListVersion.cshtml#L9
if that is preferred.

/CC @ferventcoder 

fixes #493 