### PR TITLE
(GH-486) Added check if existing packages is in submitted state

### DIFF
--- a/chocolatey/Website/Controllers/ApiController.cs
+++ b/chocolatey/Website/Controllers/ApiController.cs
@@ -165,6 +165,14 @@ namespace NuGetGallery
                     return new HttpStatusCodeWithBodyResult(
                         HttpStatusCode.Forbidden,
                         string.Format("The package {0} have a previous version in a submitted state, and no approved stable releases.",
+                            packageToPush.Id),
+                        string.Format(@"
+Please wait until a minimum of 1 version of the {0} package have been approved,
+before pushing a new version.
+
+If the package is currently failing, please see any failure emails sent
+out on why it could be failing, as well as instructions on how to fix
+any moderation related failures.",
                             packageToPush.Id));
                 }
             }

--- a/chocolatey/Website/Controllers/ApiController.cs
+++ b/chocolatey/Website/Controllers/ApiController.cs
@@ -159,6 +159,14 @@ namespace NuGetGallery
                             return new HttpStatusCodeWithBodyResult(HttpStatusCode.Conflict, String.Format(CultureInfo.CurrentCulture, Strings.PackageExistsAndCannotBeModified, packageToPush.Id, packageToPush.Version));
                     }
                 }
+                else if(!packageRegistration.Packages.Any(p => !p.IsPrerelease && p.Status == PackageStatusType.Approved)
+                      && packageRegistration.Packages.Any(p => p.Status == PackageStatusType.Submitted))
+                {
+                    return new HttpStatusCodeWithBodyResult(
+                        HttpStatusCode.Forbidden,
+                        string.Format("The package {0} have a previous version in a submitted state, and no approved stable releases.",
+                            packageToPush.Id));
+                }
             }
 
             try


### PR DESCRIPTION
With this change only packages with at least one approved
stable release is allowed to push multiple new versions.
PreReleases are also considered when checking if a version
is in the submitted state (Ignored if they are approved/Exempted though).

fixes #486 
