### PR TITLE
(GH-497) Bug/bundling optimization

### DIFF
--- a/chocolatey/Website/Content/style.css
+++ b/chocolatey/Website/Content/style.css
@@ -2523,10 +2523,6 @@ img  { max-width: 100%; }
   box-shadow: 5px 7px 50px rgba(0,0,0,.2);
 }
 
-.terminal-chrome__close {
-  content: '\c02715';
-}
-
 .terminal-chrome-top {
   position: absolute;
   left: 0;

--- a/chocolatey/Website/Content/style.css
+++ b/chocolatey/Website/Content/style.css
@@ -104,8 +104,8 @@ button {
 }
 @-webkit-keyframes fa-spin  {
   0%  {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
   }
   100%  {
     -webkit-transform: rotate(359deg);
@@ -114,8 +114,8 @@ button {
 }
 @keyframes fa-spin  {
   0%  {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
+    -webkit-transform: rotate(0);
+    transform: rotate(0);
   }
   100%  {
     -webkit-transform: rotate(359deg);
@@ -2102,10 +2102,6 @@ ul, header, main, h1, h2, h3, h4, h5 {
   margin: 0;
 }
 
-main
- {
-}
-
 .container-wide {
   margin: auto;
   max-width: 1400px;
@@ -2362,9 +2358,6 @@ small, .small { font-size: .9em !important; }
 .quarter { width: 25%; }
 .fifth { width: calc(100% / 5); }
 
-.quarter, .fifth {
-}
-
 .flex { display: flex; flex-direction: row; }
 .flex-wrap { display: flex; flex-wrap: wrap; }
 
@@ -2439,9 +2432,6 @@ a  {
   color: inherit;
   text-decoration: none;
   transition: opacity 500ms;
-}
-
-.bg-yellow {
 }
 
 .line-height-small {
@@ -2887,7 +2877,7 @@ img  { max-width: 100%; }
   }
 
 .message--collapsed {
-  max-height: 0px;
+  max-height: 0;
 }
 
 .message__close {
@@ -3281,7 +3271,7 @@ ul.docs li:before {
 table {
   font-size: .9em;
   width: 100%;
-  border-spacing: 0px;
+  border-spacing: 0;
 }
 
 table th {
@@ -3447,7 +3437,7 @@ fieldset.form  {
             background-image: -webkit-linear-gradient(top, #1A375A 0%, #21446D 100%);
             background-image: linear-gradient(top, #1A375A 0%, #21446D 100%);
             border: solid 1px #21446D;
-            box-shadow: inset 0px 0px 1px rgba(255,255,255,1), 1px 1px 1px rgba(0,0,0,0.3);
+            box-shadow: inset 0 0 1px rgba(255,255,255,1), 1px 1px 1px rgba(0,0,0,0.3);
             color: #fff;
             cursor: pointer;
             font-size: 1.25em;
@@ -3513,7 +3503,7 @@ fieldset.form  {
         .sexy-table th  {
             font-size: 1.25em;
             font-weight: normal;
-            padding: 5px 15px 0px 0px;
+            padding: 5px 15px 0 0;
             text-align:left;
         }
         

--- a/chocolatey/Website/Infrastructure/CassetteConfiguration.cs
+++ b/chocolatey/Website/Infrastructure/CassetteConfiguration.cs
@@ -34,8 +34,7 @@ namespace NuGetGallery
             bundles.AddPerIndividualFile<StylesheetBundle>("Content", new FileSearch
             {
                 Pattern = "*.css",
-                SearchOption = SearchOption.AllDirectories,
-                Exclude = new Regex("style\\.css$")
+                SearchOption = SearchOption.AllDirectories
             });
 #if DEBUG
             bundles.AddPerSubDirectory<ScriptBundle>("Scripts", new FileSearch

--- a/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
+++ b/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
@@ -15,9 +15,7 @@
   }
 
   //css
-  //Bundles.Reference("Content/style.css");
-  //Bundles.Reference("Content/site.css");
-  //Bundles.Reference("Content/chocolatey.css");
+  Bundles.Reference("Content/style.css");
   //js
   Bundles.Reference("Scripts");
   Bundles.Reference("Scripts/header", "header");
@@ -39,7 +37,6 @@
   <meta property="og:image:height" content="700" />
   <meta property="copyright" content="Chocolatey is Copyright 2011 - @DateTime.UtcNow.Year RealDimensions Software, LLC - a US-based company."/> 
   @Bundles.RenderStylesheets()
-  <link href="@Url.Content("~/content/style.css")?update=20161223" rel="stylesheet" />
   @RenderSection("css", required: false)
   <link href="@Url.Content("~/favicon.ico")" rel="shortcut icon" type="image/x-icon" />
   <link rel="nuget" type="application/atom+xml" title="Chocolatey" href="http://www.chocolatey.org/api/v2" />

--- a/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
+++ b/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Configuration
-@using NuGetGallery;
 @using StackExchange.Profiling
 @{
   if (!ViewData.ContainsKey(Constants.ReturnUrlViewDataKey) || string.IsNullOrWhiteSpace((string)ViewData[Constants.ReturnUrlViewDataKey]))


### PR DESCRIPTION
References Issue #497 
Failed PR at #503 

@ferventcoder - Being you expressed a desire to work with Cassette, I went ahead and got it working with the current `style.css` file that you are serving in production. 

### Issue
As Cassette went through its build logic, it was running up against a class style that it appeared to be interpreting as UTF16 but had an expectation of UTF32.  Of which, was throwing an out-of-range error.  Long story short, there is a bug inside of Cassette. 

### Fix
 The offending style was `.terminal-chrome__close`.  Removing it has zero effect on the UI.  I am assuming the content type of `\c02715` produces an **X** value, of which you have replaced with `&times;`.  That being said, I removed it from `style.css` and verified the UI was unchanged. 

### Optimization
There were a few low-hanging-fruit things I did in the style sheet.  The commit notes should clearly outline them. 

### Thoughts
Personally, I dislike Cassette.  There are odd constructs enforced to manipulate your desired outcome. Of which to me, speaks to its age.  

* Forcing a full build to view changes seems like a nightmare for development.
* No guarantee you will not run into this bug again.
* Building bundles around none explicit configuration is not intuitive to desired expectations.

Yes, it works but I believe there are better options available today that align a bit more with how the web works.

### Results
| style.css  | Size |
| ------------- | ------------- |
| Current Production  | 62.6kb  |
| Pull Request | 46.9kb  | 

Every kb counts, :smile: