### PR TITLE
Remove dots from header ids

### DIFF
--- a/UpdateDocumentation.ps1
+++ b/UpdateDocumentation.ps1
@@ -9,6 +9,12 @@ try {
 
 git submodule update --remote --rebase
 
+function CleanUpHeaderIds($text) {
+  $text | % {
+    [Regex]::Replace($_, '<h\d id="[^"]+', { $args[0] -replace '\.', '' })
+  }
+}
+
 # https://github.com/jgm/pandoc/issues/2923
 function Convert-MarkdownLinks($text) {
 
@@ -101,7 +107,7 @@ Get-ChildItem -Path choco.wiki -Recurse -ErrorAction SilentlyContinue -Filter *.
   #+simple_tables+native_spans+native_divs+multiline_tables
   & pandoc.exe --from markdown_github --to html5 --old-dashes --no-highlight -V lang="en" -B docgen/header.txt -A docgen/footer.txt -o "$htmlFileName" "$($_.FullName)"
 
-  $fileContent = Convert-SeoUrls (Convert-ImageUrls (Convert-FencedCode (Fix-MarkdownConversion (Convert-MarkdownLinks (Get-Content $htmlFileName).Replace("@","@@").Replace("{{AT}}","@").Replace("{{DocName}}",$docName)))))
+  $fileContent = Convert-SeoUrls (Convert-ImageUrls (Convert-FencedCode (Fix-MarkdownConversion (Convert-MarkdownLinks (CleanUpHeaderIds (Get-Content $htmlFileName).Replace("@","@@").Replace("{{AT}}","@").Replace("{{DocName}}",$docName))))))
   $firstLine = Get-FirstLine($fileContent)
   $firstLine -= 1
   Write-Debug "Line number is $firstLine"


### PR DESCRIPTION
Workaround for a discrepancy between GitHub and Pandoc output.

Pandoc keeps dots in ids while GitHub doesn't:
https://github.com/chocolatey/choco/wiki/Installation#install-with-cmdexe (leads right to the section)
https://chocolatey.org/install#install-with-cmdexe (leads nowhere)

