### PR TITLE
do not output the created temporary directory

### DIFF
--- a/chocolatey/Website/Install.ps1
+++ b/chocolatey/Website/Install.ps1
@@ -46,7 +46,7 @@ if ($env:TEMP -eq $null) {
 }
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
 $tempDir = Join-Path $chocTempDir "chocInstall"
-if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
+if (![System.IO.Directory]::Exists($tempDir)) {[void][System.IO.Directory]::CreateDirectory($tempDir)}
 $file = Join-Path $tempDir "chocolatey.zip"
 
 # PowerShell v2/3 caches the output stream. Then it throws errors due


### PR DESCRIPTION
Do not output the creation of the temporary `chocInstall` directory:

```plain
==> default: Running C:\vagrant\provision-chocolatey.ps1...
==> default: Downloading specific version of Chocolatey: 0.10.7
==> default: Mode                LastWriteTime         Length Name                                                                  
==> default: ----                -------------         ------ ----                                                                  
==> default: d-----         8/7/2017   6:42 AM                chocInstall                                                           
==> default: Getting Chocolatey from https://chocolatey.org/api/v2/package/chocolatey/0.10.7.
```