### PR TITLE
Add Ansible to the text of the homepage.

### DIFF
--- a/chocolatey/Website/Views/Documentation/About.cshtml
+++ b/chocolatey/Website/Views/Documentation/About.cshtml
@@ -6,7 +6,7 @@
   <h1 id="about-chocolatey">About Chocolatey</h1>
 <p>Managing internal and external software is a breeze with Chocolatey! Chocolatey is a single, unified interface designed to work with all aspects of managing Windows software using a packaging framework that understands both versioning and dependency requirements.</p>
 <p>Chocolatey packages encapsulate everything required to manage a particular piece of software into one deployment artifact by wrapping installers, executables, zips, and scripts into a compiled package file.</p>
-<p>Chocolatey packages can be used independently, but also integrate with configuration managers like SCCM, Puppet, and Chef.</p>
+<p>Chocolatey packages can be used independently, but also integrate with configuration managers like SCCM, Ansible, Puppet, and Chef.</p>
 <p>Chocolatey is trusted by businesses all over the world to manage their software deployments on Windows. You’ve never had so much fun managing software!</p>
 
 </article>


### PR DESCRIPTION
Ansible was missing from the list of devops tools.