### PR TITLE
(maint) init choco.wiki submodule if folder empty

### DIFF
--- a/UpdateDocumentation.ps1
+++ b/UpdateDocumentation.ps1
@@ -7,6 +7,10 @@ try {
   exit 1
 }
 
+if ($null -eq (Get-ChildItem -Path 'choco.wiki' -File)) {
+    git submodule init
+}
+
 git submodule update --remote --rebase
 
 function CleanUpHeaderIds($text) {


### PR DESCRIPTION
When you run `UpdateDocumentation.ps1` for the first time, with an empty choco.wiki folder, the submodule does not update and the script fails to run. The first time you need to initialize the submodule and then update it.