### PR TITLE
Fix typo

### DIFF
--- a/chocolatey/Website/Views/Users/Account.cshtml
+++ b/chocolatey/Website/Views/Users/Account.cshtml
@@ -53,8 +53,7 @@
     <p>
         Your API key provides you with a token that identifies you to the gallery. 
         Keep this a secret. You can always regenerate your key at any time (invalidating 
-        previous keys) if your token is accidentally revealed. The 
-        You would pass your token like this:
+        previous keys) if your token is accidentally revealed.
     </p>
     
     <div id="generateKey">


### PR DESCRIPTION
This paragraph had the sentence: `The You would pass your token like this:`. I just removed it - I think the "Example Usage" title makes things clear enough.

By the way - this page was a sweet experience to first using the `choco push` api - everything there ready to copy and paste! 😄 

Edit: Screenshot removed, key regenerated 🤦‍♂️ 