### PR TITLE
Make selection easier

### DIFF
--- a/chocolatey/Website/Content/style.css
+++ b/chocolatey/Website/Content/style.css
@@ -4046,4 +4046,8 @@ section.package .moderator-side .waiting {
   padding: 15px;
   float:right;
   width: 450px;
+  user-select: all;
+}
+.nuget-badge-small code > span:first-child {
+  user-select: none;
 }


### PR DESCRIPTION
- Set the `code` part of `.nuget-badge-small` to `user-select: all` so that clicking it automatically selects the entire `install` command. 
- Set the `span` part to `user-select: none` so that the prompt is not selectable. 

I suggest putting classes on those elements to make them easier to target with CSS but it's not so important so I'll leave it at this.
