### PR TITLE
Update animation to use "choco install docker-desktop"

### DIFF
--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -46,7 +46,7 @@
                         <div class="terminal-chrome__close">&times;</div>
                     </div>
                     <div class="terminal-content terminal-content--min-height">
-                        choco <span data-animate="install docker,upgrade nodejs,uninstall flashplayer,search nodejs --id-starts-with,info docker">install docker</span><span class="terminal-cursor"></span>
+                        choco <span data-animate="install docker-desktop,upgrade nodejs,uninstall flashplayer,search nodejs --id-starts-with,info docker-desktop">install docker-desktop</span><span class="terminal-cursor"></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
After discussion in ahmetb/docker-chocolatey#49 and riezebosch/BoxstarterPackages#27 I've decided to move the choco package "docker" to "docker-cli".

Now the landing page at chocolatey.org must be updated to use something more meaningful than "choco install docker". So here is a PR for it to use the latest Docker Desktop instead with a "choco install docker-desktop"
