### PR TITLE
(GH-645) Add ContactAdmins view model

### DIFF
--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -535,7 +535,7 @@ namespace NuGetGallery
 
             if (package == null) return PackageNotFound(id, version);
 
-            var model = new ReportAbuseViewModel
+            var model = new ContactAdminsViewModel
             {
                 PackageId = id,
                 PackageVersion = package.Version,
@@ -551,7 +551,7 @@ namespace NuGetGallery
         }
 
         [HttpPost, ValidateAntiForgeryToken, ValidateFormResponse]
-        public virtual ActionResult ContactAdmins(string id, string version, ReportAbuseViewModel reportForm)
+        public virtual ActionResult ContactAdmins(string id, string version, ContactAdminsViewModel reportForm)
         {
             if (!ModelState.IsValid) return ContactAdmins(id, version);
 

--- a/chocolatey/Website/PackagesController.generated.cs
+++ b/chocolatey/Website/PackagesController.generated.cs
@@ -293,7 +293,7 @@ namespace NuGetGallery {
         }
 
 
-        public override System.Web.Mvc.ActionResult ContactAdmins(string id, string version, NuGetGallery.ReportAbuseViewModel reportForm) {
+        public override System.Web.Mvc.ActionResult ContactAdmins(string id, string version, NuGetGallery.ContactAdminsViewModel reportForm) {
             var callInfo = new T4MVC_ActionResult(Area, Name, ActionNames.ContactAdmins);
 
 

--- a/chocolatey/Website/ViewModels/ContactAdminsViewModel.cs
+++ b/chocolatey/Website/ViewModels/ContactAdminsViewModel.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
+// authors/contributors from ChocolateyGallery
+// at https://github.com/chocolatey/chocolatey.org,
+// and the authors/contributors of NuGetGallery
+// at https://github.com/NuGet/NuGetGallery
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
+using NuGetGallery.Infrastructure;
+
+namespace NuGetGallery
+{
+    public class ContactAdminsViewModel : ISpamValidationModel
+    {
+        public string PackageId { get; set; }
+        public string PackageVersion { get; set; }
+
+        [AllowHtml]
+        [Required]
+        [StringLength(4000)]
+        [Display(Name = "Contact Admins")]
+        public string Message { get; set; }
+
+        [Display(Name = "Send me a copy")]
+        public bool CopySender { get; set; }
+
+        [Required(ErrorMessage = "Please enter your email address.")]
+        [StringLength(4000)]
+        [DataType(DataType.EmailAddress)]
+        [RegularExpression(@"[.\S]+\@[.\S]+\.[.\S]+", ErrorMessage = "This doesn't appear to be a valid email address.")]
+        public string Email { get; set; }
+
+        public bool ConfirmedUser { get; set; }
+
+        [ScaffoldColumn(false)]
+        public string SpamValidationResponse { get; set; }
+    }
+}

--- a/chocolatey/Website/Views/Packages/ContactAdmins.cshtml
+++ b/chocolatey/Website/Views/Packages/ContactAdmins.cshtml
@@ -1,4 +1,4 @@
-﻿@model ReportAbuseViewModel
+﻿@model ContactAdminsViewModel
 @{
   ViewBag.Tab = "Packages";
   Bundles.Reference("Scripts/validation");

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -797,6 +797,7 @@
     <Compile Include="Services\SearchResults.cs" />
     <Compile Include="Services\UploadFileService.cs" />
     <Compile Include="Services\UserService.cs" />
+    <Compile Include="ViewModels\ContactAdminsViewModel.cs" />
     <Compile Include="ViewModels\ContactUsViewModel.cs" />
     <Compile Include="ViewModels\DiscountViewModel.cs" />
     <Compile Include="ViewModels\ListPackageItemViewModel.cs" />


### PR DESCRIPTION
The Report Abuse form and the Contact Admins form previously shared the
ReportAbuse view model. With the addition of the required check box to
the ReportAbuse view model in a previous commit, this made the Contact
Admins form unable to submit. The Contact Admins form was expecting a
required check box element, when there was none.

A new view model has been created specifically for the Contact Admins
form, and all appropriate files have been updated to reflect the change.