### PR TITLE
(GH-648) Allow moderator to restart validator

### DIFF
--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -308,6 +308,14 @@ namespace NuGetGallery
                 newComments += "Auto Verification Change - Verification tests have been set to rerun.";
             }
 
+            bool rerunValidation = form["RerunValidation"].clean_html() == "true";
+            if (rerunValidation)
+            {
+                packageSvc.ResetPackageValidationStatus(package);
+                if (!string.IsNullOrWhiteSpace(newComments)) newComments += "{0}".format_with(Environment.NewLine);
+                newComments += "Auto Validation Change - Validation tests have been set to rerun.";
+            }
+
             bool rerunVirusScanner = form["RerunVirusScanner"].clean_html() == "true";
             if (rerunVirusScanner)
             {

--- a/chocolatey/Website/Services/IPackageService.cs
+++ b/chocolatey/Website/Services/IPackageService.cs
@@ -69,6 +69,8 @@ namespace NuGetGallery
 
         void ResetPackageTestStatus(Package package);
 
+        void ResetPackageValidationStatus(Package package);
+
         /// <summary>
         /// Saves minor package changes. Do not call this is you are listing or unlisting a package.
         /// </summary>

--- a/chocolatey/Website/Services/PackageService.cs
+++ b/chocolatey/Website/Services/PackageService.cs
@@ -1086,6 +1086,15 @@ namespace NuGetGallery
             NotifyIndexingService(package);
         }
 
+        public void ResetPackageValidationStatus(Package package)
+        {
+            package.PackageValidationResultStatus = PackageAutomatedReviewResultStatusType.Pending;
+            if (package.Status == PackageStatusType.Submitted) package.SubmittedStatus = PackageSubmittedStatusType.Pending;
+            packageRepo.CommitChanges();
+            InvalidateCache(package.PackageRegistration);
+            NotifyIndexingService(package);
+        }
+
         public void SaveMinorPackageChanges(Package package)
         {
             packageRepo.CommitChanges();

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -437,13 +437,17 @@
                     {
                        <div class="form-field">
                            <input id="RerunTests" name="RerunTests" type="checkbox" value="true" />
-                           <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun tests?</label>
+                           <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun verification tests?</label>
                        </div>
                     }
                     
                     @if (moderator && Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
                     {
-                       <div class="form-field">
+                        <div class="form-field">
+                            <input id="RerunValidation" name="RerunValidation" type="checkbox" value="true" />
+                            <label for="RerunValidation" class="for-checkbox" title="Rerun package validation tests.">Rerun validation tests?</label>
+                        </div>
+                        <div class="form-field">
                            <input id="OverrideValidation" name="OverrideValidation" type="checkbox" value="true" />
                            <label for="OverrideValidation" class="for-checkbox" title="Override package validation failures and run tests.">Override validation errors?</label>
                        </div>


### PR DESCRIPTION
Merging this allows the moderators to restart the validation tests.

See screenshot:

![image](https://user-images.githubusercontent.com/1271146/53818988-f87f1880-3f60-11e9-8b56-1576bfaab6cc.png)

Merging this fixes #648 
