### PR TITLE
Fix a warning about missing Tls 1.1/1.2 protocols

### DIFF
--- a/chocolatey/Website/Install.ps1
+++ b/chocolatey/Website/Install.ps1
@@ -85,15 +85,31 @@ Fix-PowerShellOutputRedirectionBug
 # PowerShell will not set this by default (until maybe .NET 4.6.x). This
 # will typically produce a message for PowerShell v2 (just an info
 # message though)
-try {
-  # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
-  # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
-  # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
-  # installed (.NET 4.5 is an in-place upgrade).
-  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
-} catch {
+
+# Set SSL 3.0 (48), then TLS 1.0 (192), then TLS 1.1 (768), finally TLS 1.2 (3072)
+# Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
+# exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
+# installed (.NET 4.5 is an in-place upgrade).
+
+# Enumerate through protocols list; print not supported protocols as warnings
+(@{ 'Tls 1.2' = 3072; 'Tls 1.1' = 768; 'Tls 1.0' = 192; 'SSL 3.0' = 48 }).GetEnumerator() | Sort-Object -Property key | ForEach-Object {
+  $temp = $_
+  try {
+    [System.Net.ServicePointManager]::SecurityProtocol = $_.Value
+  } catch {
+    Write-Output "[Warning] $($temp.Key) protocol not supported."
+  }
+}
+
+# Get the highest available encryption
+# Print warning if SecurityProtocol is not TLS 1.2 or TLS 1.1
+# Print the encryption
+$securityProtocol = [System.Net.ServicePointManager]::SecurityProtocol.toString().ToLower()
+
+if ($securityProtocol -ne 'tls11' -AND $securityProtocol -ne 'tls12') {
   Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5+ and PowerShell v3, (2) specify internal Chocolatey package location (set $env:chocolateyDownloadUrl prior to install or host the package internally), (3) use the Download + PowerShell method of install. See https://chocolatey.org/install for all install options.'
 }
+Write-Output "Security protocol set: $($securityProtocol)"
 
 function Get-Downloader {
 param (


### PR DESCRIPTION
A warning could be issued, even if the protocols are present and a
correct .Net Framework is installed.

It's enough to trigger the warning just when SSL is not supported - and
now it's absent in PowerShell 6.1.x, so the warning is always there.

It's because the "try {}" block tests the whole following line:
"(...) 3072 -bor 768 -bor 192 -bor 48" and fails on "-bor 48" part.

What's changed is that now foreach loop tries to set a highest
encryption available by testing the protocols one by one, from SSL until
Tls 1.2. "catch {}" block is triggered when a specific protocol is
absent and the final "if" block checks the final selected encryption
(if it's Tls 1.2 or 1.1).

The solution works for PowerShell 2.x - 6.1.x.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/chocolatey.org#contributing

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
