### PR TITLE
(GH-684) Add X-Frame-Options header for IIS

### DIFF
--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -320,6 +320,12 @@
     <handlers>
       <add name="CassetteHttpHandler" path="cassette.axd" preCondition="integratedMode" verb="*" allowPathInfo="true" type="Cassette.Aspnet.CassetteHttpHandler, Cassette.Aspnet" />
     </handlers>
+    <!-- X-Frame-Options header for IIS -->
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="deny" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
A snippet has been added to Web.config to allow IIS to send the X-Frame-Options header. This X-Frame-Options header is used to avoid clickjacking attacks by ensuring that content on Chocolatey.org can not be embedded into other sites.

More information about this response header can be found at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options