### PR TITLE
upgrade if already installed

### DIFF
--- a/chocolatey/Website/Install.ps1
+++ b/chocolatey/Website/Install.ps1
@@ -17,9 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =====================================================================
-$ChocoVersionRegex = '^(\d+)\.(\d+)\.(\d+)$'
-$testchoco = (powershell choco -v)
-if( $testchoco -Match $ChocoVersionRegex ) {
+
+if( Get-Command choco.exe -ErrorAction Ignore ) {
     choco update
 } else {
 # For organizational deployments of Chocolatey, please see https://chocolatey.org/docs/how-to-setup-offline-installation

--- a/chocolatey/Website/Install.ps1
+++ b/chocolatey/Website/Install.ps1
@@ -17,7 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # =====================================================================
-
+$ChocoVersionRegex = '^(\d+)\.(\d+)\.(\d+)$'
+$testchoco = (powershell choco -v)
+if( $testchoco -Match $ChocoVersionRegex ) {
+    choco update
+} else {
 # For organizational deployments of Chocolatey, please see https://chocolatey.org/docs/how-to-setup-offline-installation
 
 # Environment Variables, specified as $env:NAME in PowerShell.exe and %NAME% in cmd.exe.
@@ -263,7 +267,7 @@ $chocoPkgDir = Join-Path $chocoPath 'lib\chocolatey'
 $nupkg = Join-Path $chocoPkgDir 'chocolatey.nupkg'
 if (![System.IO.Directory]::Exists($chocoPkgDir)) { [System.IO.Directory]::CreateDirectory($chocoPkgDir); }
 Copy-Item "$file" "$nupkg" -Force -ErrorAction SilentlyContinue
-
+}
 # SIG # Begin signature block
 # MIIcpwYJKoZIhvcNAQcCoIIcmDCCHJQCAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG


### PR DESCRIPTION
Per issue chocolatey#164, choco will preform an upgrade if it is already installed.

I chose to test for chocolatey's presence by evaluating the output of `powershell choco -v`  with regex because I was having reliability issues when simply testing for the success of `powershell choco -v`.