### PR TITLE
(GH-699) Fix relevance in search results

### DIFF
--- a/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery
             document.Add(new Field("Id-Original", Package.PackageRegistration.Id, Field.Store.YES, Field.Index.NO));
 
             var field = new Field("Id-Exact", Package.PackageRegistration.Id.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED);
-            field.Boost = 2.5f;
+            field.Boost = 4.5f;
             document.Add(field);
             
             // We store the Id/Title field in multiple ways, so that it's possible to match using multiple
@@ -78,9 +78,13 @@ namespace NuGetGallery
 
             // title fields
             // If an element does not have a Title, fall back to Id, same as the website.
-            var workingTitle = String.IsNullOrEmpty(Package.Title)
+            var workingTitle = string.IsNullOrEmpty(Package.Title)
                                    ? Package.PackageRegistration.Id
                                    : Package.Title;
+
+            field = new Field("Title-Exact", workingTitle.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED);
+            field.Boost = 4.0f;
+            document.Add(field);
 
             // As-Is (stored for search results)
             field = new Field("Title", workingTitle, Field.Store.YES, Field.Index.ANALYZED);

--- a/chocolatey/Website/Views/Documentation/Installation.cshtml
+++ b/chocolatey/Website/Views/Documentation/Installation.cshtml
@@ -40,7 +40,7 @@
 <li><a href="#more-install-options" onclick="document.getElementById('div-moreoptions').classList.remove('d-none')">More Options</a> / <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "troubleshooting" })">Troubleshooting</a></li>
 </ul>
 <h4 id="install-with-cmdexe">Install with cmd.exe</h4>
-<p>Run the following command:  <button class="btn btn-secondary btn-copy font-weight-bold" data-clipboard-text="@@&quot;%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command &quot;iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))&quot; && SET &quot;PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin&quot;"><span class="fad fa-clipboard"></span> Copy Command Text</button> </p>
+<p>Run the following command:  <button class="btn btn-secondary btn-copy font-weight-bold" data-clipboard-text="@@&quot;%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command &quot;iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))&quot; && SET &quot;PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin&quot;"><span class="fas fa-clipboard"></span> Copy Command Text</button> </p>
 <pre><code class="language-none">
 @@&quot;%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe&quot; -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command &quot;iex ((New-Object System.Net.WebClient).DownloadString(&#39;https://chocolatey.org/install.ps1&#39;))&quot; &amp;&amp; SET &quot;PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin&quot;
 </code></pre>
@@ -48,7 +48,7 @@
 <p>With PowerShell, there is an additional step. You must ensure <a href="https://go.microsoft.com/fwlink/?LinkID=135170">Get-ExecutionPolicy</a> is not Restricted. We suggest using <code>Bypass</code> to bypass the policy to get things installed or <code>AllSigned</code> for quite a bit more security.</p>
 <ul>
 <li>Run <code>Get-ExecutionPolicy</code>. If it returns <code>Restricted</code>, then run <code>Set-ExecutionPolicy AllSigned</code> or <code>Set-ExecutionPolicy Bypass -Scope Process</code>.</li>
-<li>Now run the following command:  <button class="btn btn-secondary btn-copy font-weight-bold" data-clipboard-text="Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"><span class="fad fa-clipboard"></span> Copy Command Text</button> </li>
+<li>Now run the following command:  <button class="btn btn-secondary btn-copy font-weight-bold" data-clipboard-text="Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"><span class="fas fa-clipboard"></span> Copy Command Text</button> </li>
 </ul>
 <pre><code class="language-powershell">
 Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString(&#39;https://chocolatey.org/install.ps1&#39;))


### PR DESCRIPTION
Id and Title need to be boosted quite a bit more in relevance for
search results. Add them to the package index entity with a higher
boost on id and title.

- Increase Id-Exact field to 4.5f from 2.5f in the index
- Add an Title-Exact field and give it a 4.0f boost in the index
- In the AND query (conjunction), boost it from 2.0f to 4.0f
- Boost exact Id query from 2.5f to 7.0f
- Add exact title query to search against Title-Exact with a 5.0f boost
- Add wildcard Title query to search against title.
- Remove the download count boosting on search results by relevance

Closes #699