### PR TITLE
(GH-675) Restart package cacher for a package

### DIFF
--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -325,6 +325,16 @@ namespace NuGetGallery
                 newComments += "Virus Scanner has ben set to rerun";
             }
 
+            bool rerunPackageCacher = form["RerunPackageCacher"].clean_html() == "true";
+            if (rerunPackageCacher)
+            {
+                package.DownloadCacheStatus = PackageDownloadCacheStatusType.Unknown;
+                packageSvc.SaveMinorPackageChanges(package);
+                if (!string.IsNullOrWhiteSpace(newComments)) newComments += "{0}".format_with(Environment.NewLine);
+                newComments += "Customer CDN Download cacher has ben set to rerun";
+
+            }
+
             // could be null if no moderation has happened yet
             var moderator = isModerationRole ? currentUser : package.ReviewedBy;
 

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -26,6 +26,7 @@
     var packageVersions = Model.PackageVersions.Count();
     var packageVersionsDefaultDisplay = 10;
 
+    var admin = User != null && User.IsAdmin();
     var maintainer = User != null && Model.Owners.Any(u => u.Username == User.Identity.Name);
     var moderator = User != null && User.IsModerator() && !maintainer;
     var moderationRole = User != null && User.IsInAnyModerationRole() && !maintainer;
@@ -1073,6 +1074,13 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                             <div class="form-field">
                                                 <input id="RerunVirusScanner" name="RerunVirusScanner" type="checkbox" value="true" />
                                                 <label for="RerunVirusScanner" class="for-checkbox" title="Rerun virus scanner to get latest reports.">Rerun virus scanner?</label>
+                                                    </div>
+                                                }
+                                                @if (admin)
+                                                {
+                                                    <div class="form-field">
+                                                        <input id="RerunPackageCacher" name="RerunPackageCacher" type="checkbox" value="true" />
+                                                        <label for="RerunPackageCacher" class="for-checkbox" title="Rerun Customer CDN cacher to update cache.">Rerun package CDN cacher?</label>
                                             </div>
                                         }
                                         @if (moderationRole)


### PR DESCRIPTION
This allows us to restart the package-cacher
for an existing package, giving us the possibility
to trigger a new download of the cached version of
installers.

Merging this closes #675 