### PR TITLE
(layout) Make collapsed elements navigatable by url

### DIFF
--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -82,26 +82,41 @@ $(document).ready(function () {
     }
 });
 
-// Opens tabbed information based on hash
+// Opens tabbed/collapse information based on hash
 $(function () {
-    var urlTab = document.location.toString();
-    if (urlTab.match('#')) {
-        var tabNav = $('.nav-tabs a[href="#' + urlTab.split('#')[1] + '"]');
+    var urlHash = document.location.toString();
+    if (urlHash.match('#')) {
+        var tabNav = $('[data-toggle="tab"][href="#' + urlHash.split('#')[1] + '"]');
         var parentTabNav = '#' + tabNav.parentsUntil('.tab-pane').parent().addClass('tab-nested');
         parentTabNav = $('#' + $('.tab-pane.tab-nested').prop('id') + '-tab');
         // Open Tabs
         parentTabNav.tab('show');
         tabNav.tab('show');
+
+        // Toggle Collpase
+        var collapseNav = $($('[data-toggle="collapse"][href="#' + urlHash.split('#')[1] + '"]').attr('href'));
+        collapseNav.collapse('show');
+
+        // Scroll Tabs
         if (parentTabNav.length) {
             $('html, body').scrollTop(parentTabNav.offset().top - 30);
         }
         else if (tabNav.length) {
-            $('html, body').scrollTop(tabNav.offset().top -30);
+            $('html, body').scrollTop(tabNav.offset().top - 30);
         }
-        
+        // Scroll Collapse
+        if (collapseNav.length) {
+            collapseNav.on('shown.bs.collapse', function () {
+                if (/pricing/.test(window.location.href)) {
+                    $('html, body').scrollTop($(this).offset().top - 120);
+                } else {
+                    $('html, body').scrollTop($(this).offset().top - 60);
+                }
+            });
+        }
     }
-    // Change hash on tab click and prevent scrolling
-    $('.nav-tabs a').click(function (e) {
+    // Change hash on tab/collapse click and prevent scrolling
+    $('[data-toggle="tab"], [data-toggle="collapse"]').click(function (e) {
         if (history.pushState) {
             history.pushState(null, null, e.target.hash);
         } else {
@@ -152,8 +167,12 @@ $(document).on('click', 'input[type=text]', function () {
 });
 
 // Toggle and scroll to collapse elements on click
-$('a[href*="#"]').not('[data-toggle="tab"]').click(function () {
-    $(this.hash).find('a[data-toggle="collapse"]').next().collapse('show');
+$('.collapse-nav').click(function () {
+    $(this).parent().parent().find(".active").removeClass("active");
+    $(this).addClass('active');
+    $(this.hash).on('shown.bs.collapse', function () {
+        $('html, body').animate({ scrollTop: $(this).offset().top - 120 }, 1100);
+    });
 });
 
 // Smooth Scroll

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -382,171 +382,165 @@
         </div>
         @*  MAIN  *@
         <div class="col-md-9 col-xl-10">
-            <div class="row">
-                <div class="col-12 mb-3 d-none d-md-block">
-                    <h1 class="justify-content-center align-items-center d-flex mb-0" title="Nuspec reference: &lt;title&gt;@Model.Title&lt;/title&gt;">
-                        <span class="d-flex">
-                            <a class="status" href="#status" title="Click to view test results">
-                                <span class="@Model.PackageValidationResultStatus"></span>
-                                <span class="@Model.PackageTestResultsStatus"></span>
-                            </a>
-                        </span>
-                        @Model.Title
-                        @if (Model.Status != PackageStatusType.Rejected)
-                        {
-                            <span class="ml-2" title="Nuspec reference: &lt;version&gt;@Model.Version&lt;/version&gt;">@Model.Version</span>
-                        }
-                    </h1>
-                    @if (Model.Status == PackageStatusType.Submitted)
+            <div class="mb-3 d-none d-md-block">
+                <h1 class="justify-content-center align-items-center d-flex mb-0" title="Nuspec reference: &lt;title&gt;@Model.Title&lt;/title&gt;">
+                    <span class="d-flex">
+                        <a class="status" href="#status" title="Click to view test results">
+                            <span class="@Model.PackageValidationResultStatus"></span>
+                            <span class="@Model.PackageTestResultsStatus"></span>
+                        </a>
+                    </span>
+                    @Model.Title
+                    @if (Model.Status != PackageStatusType.Rejected)
                     {
-                        <h5 class="text-center">(@packageStatus)</h5>
+                        <span class="ml-2" title="Nuspec reference: &lt;version&gt;@Model.Version&lt;/version&gt;">@Model.Version</span>
                     }
-                    @if (Model.Prerelease)
-                    {
-                        <p class="text-center text-warning"><strong>This is a prerelease version of @Model.Title.</strong></p>
-                    }
-                    else if (!Model.IsLatestVersionAvailable && Model.Status != PackageStatusType.Submitted && Model.Status != PackageStatusType.Rejected)
-                    {
-                        <p class="text-center text-warning"><strong>This is not the <a href="@Url.Package(Model.Id)" title="View the latest version">latest version</a> of @Model.Title available.</strong></p>
-                    }
-                    @if (packageFileMayNotBeUpdatedYetOnCdn)
-                    {
-                        <p class="text-center text-danger"><strong>WARNING! The package (the *.nupkg file) is subject to a CDN with a 30 minute timeout. If you have pushed an updated version, please wait for more than 30 minutes before attempting to install from the site.</strong></p>
-                    }
-                </div>
+                </h1>
+                @if (Model.Status == PackageStatusType.Submitted)
+                {
+                    <h5 class="text-center">(@packageStatus)</h5>
+                }
+                @if (Model.Prerelease)
+                {
+                    <p class="text-center text-warning"><strong>This is a prerelease version of @Model.Title.</strong></p>
+                }
+                else if (!Model.IsLatestVersionAvailable && Model.Status != PackageStatusType.Submitted && Model.Status != PackageStatusType.Rejected)
+                {
+                    <p class="text-center text-warning"><strong>This is not the <a href="@Url.Package(Model.Id)" title="View the latest version">latest version</a> of @Model.Title available.</strong></p>
+                }
+                @if (packageFileMayNotBeUpdatedYetOnCdn)
+                {
+                    <p class="text-center text-danger"><strong>WARNING! The package (the *.nupkg file) is subject to a CDN with a 30 minute timeout. If you have pushed an updated version, please wait for more than 30 minutes before attempting to install from the site.</strong></p>
+                }
             </div>
             @* Pass/Fail Statuses *@
-            <div id="status" class="row">
-                <div class="col-12">
-                    <div class="callout p-0 @if(testingStatusWarning || testingStatusPending){<text>callout-warning</text>}else if(testingStatusPassing){<text>callout-success</text>}else if(testingStatusFailing){<text>callout-danger</text>}else if(testingStatusUnknown || testingStatusExempt){<text>callout-secondary</text>}">
-                        <div class="d-flex justify-content-between p-3">
-                            <div class="d-flex">
-                                <div class="d-flex">
-                                    <span class="status">
-                                        <span class="@Model.PackageValidationResultStatus"></span>
-                                        <span class="@Model.PackageTestResultsStatus"></span>
-                                    </span>
-                                </div>
-                                <div>
-                                    @if (testingStatusWarning)
-                                    {
-                                        if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Exempted || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Exempted)
-                                        {
-                                            if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                            {
-                                                <h3>Some Checks Are Exempted or Have Failed</h3>
-                                            }
-                                            else if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Pending || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Pending)
-                                            {
-                                                <h3>Some Checks Are Exempted or Are Not Yet Complete</h3>
-                                            }
-                                            else
-                                            {
-                                                <h3>This Package Contains an Exempted Check</h3>
-                                            }
-                                        }
-                                        else
-                                        {
-                                            <h3>Some Checks Have Failed or Are Not Yet Complete</h3>
-                                        }
-                                        <p>1 Test @Model.PackageValidationResultStatus and 1 @Model.PackageTestResultsStatus Test</p>
-                                    }
-                                    else if (testingStatusPassing)
-                                    {
-                                        <h3 class="text-success">All Checks are Passing</h3>
-                                        <p>2 Passing Test</p>
-                                    }
-                                    else if (testingStatusFailing)
-                                    {
-                                        <h3 class="text-danger">All Checks are Failing</h3>
-                                        <p>2 Failing Test</p>
-                                    }
-                                    else if (testingStatusPending)
-                                    {
-                                        <h3 class="text-warning">All Checks are Pending</h3>
-                                        <p>2 Pending Test</p>
-                                    }
-                                    else if (testingStatusUnknown)
-                                    {
-                                        <h3 class="text-secondary">All Checks are Unknown</h3>
-                                        <p>2 Test of Unknown Status</p>
-                                    }
-                                    else if (testingStatusExempt)
-                                    {
-                                        <h3 class="text-secondary">This Package is Exempt from Testing</h3>
-                                        <p>2 Exempt Test</p>
-                                    }
-                                </div>
-                            </div>
-                            <div class="d-none d-xl-block">
-                                <a class="@if(!testingStatusPassing){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#testingResults" role="button" aria-expanded="true" aria-controls="testing results" title="Testing Results">@if (!testingStatusPassing)
-                                {<text>Hide Checks</text>}
-                                 else
-                                {<text>Show Checks</text>}</a>
-                            </div>
+            <div id="status" class="callout p-0 @if(testingStatusWarning || testingStatusPending){<text>callout-warning</text>}else if(testingStatusPassing){<text>callout-success</text>}else if(testingStatusFailing){<text>callout-danger</text>}else if(testingStatusUnknown || testingStatusExempt){<text>callout-secondary</text>}">
+                <div class="d-flex justify-content-between p-3">
+                    <div class="d-flex">
+                        <div class="d-flex">
+                            <span class="status">
+                                <span class="@Model.PackageValidationResultStatus"></span>
+                                <span class="@Model.PackageTestResultsStatus"></span>
+                            </span>
                         </div>
-                        <div class="px-3 pb-3 d-xl-none">
-                            <a class="@if(!testingStatusPassing){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#testingResults" role="button" aria-expanded="true" aria-controls="testing results" title="Testing Results">@if (!testingStatusPassing)
-                            {<text>Hide Checks</text>}
+                        <div>
+                            @if (testingStatusWarning)
+                            {
+                                if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Exempted || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Exempted)
+                                {
+                                    if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
+                                    {
+                                        <h3>Some Checks Are Exempted or Have Failed</h3>
+                                    }
+                                    else if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Pending || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Pending)
+                                    {
+                                        <h3>Some Checks Are Exempted or Are Not Yet Complete</h3>
+                                    }
+                                    else
+                                    {
+                                        <h3>This Package Contains an Exempted Check</h3>
+                                    }
+                                }
+                                else
+                                {
+                                    <h3>Some Checks Have Failed or Are Not Yet Complete</h3>
+                                }
+                                <p>1 Test @Model.PackageValidationResultStatus and 1 @Model.PackageTestResultsStatus Test</p>
+                            }
+                            else if (testingStatusPassing)
+                            {
+                                <h3 class="text-success">All Checks are Passing</h3>
+                                <p>2 Passing Test</p>
+                            }
+                            else if (testingStatusFailing)
+                            {
+                                <h3 class="text-danger">All Checks are Failing</h3>
+                                <p>2 Failing Test</p>
+                            }
+                            else if (testingStatusPending)
+                            {
+                                <h3 class="text-warning">All Checks are Pending</h3>
+                                <p>2 Pending Test</p>
+                            }
+                            else if (testingStatusUnknown)
+                            {
+                                <h3 class="text-secondary">All Checks are Unknown</h3>
+                                <p>2 Test of Unknown Status</p>
+                            }
+                            else if (testingStatusExempt)
+                            {
+                                <h3 class="text-secondary">This Package is Exempt from Testing</h3>
+                                <p>2 Exempt Test</p>
+                            }
+                        </div>
+                    </div>
+                    <div class="d-none d-xl-block">
+                        <a class="@if(!testingStatusPassing){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#testingResults" role="button" aria-expanded="true" aria-controls="testing results" title="Testing Results">@if (!testingStatusPassing)
+                        {<text>Hide Checks</text>}
                             else
-                            {<text>Show Checks</text>}</a>
-                        </div>
-                        <div class="collapse @if(!testingStatusPassing){<text>show</text>}" id="testingResults">
-                            <hr class="mt-0" />
-                            @*Validation*@
-                            <div class="px-3">
-                                @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                {
-                                    <p class="mb-0"><span class="fas fa-times text-danger mr-3"></span> Validation Testing Failed</p>
-                                }
-                                @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Passing)
-                                {
-                                    <p class="mb-0"><span class="fas fa-check text-success mr-3"></span> Validation Testing Passed</p>
-                                }
-                                @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Pending)
-                                {
-                                    <p class="mb-0"><span class="fas fa-clock text-warning mr-3"></span> Validation Testing Pending</p>
-                                }
-                                @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Unknown)
-                                {
-                                    <p class="mb-0"><span class="fas fa-question text-secondary mr-3"></span> Validation Testing Unknown</p>
-                                }
-                                @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Exempted)
-                                {
-                                    <p class="mb-0"><span class="fas fa-ban text-secondary mr-3"></span> Validation Testing Exempt</p>
-                                }
+                        {<text>Show Checks</text>}</a>
+                    </div>
+                </div>
+                <div class="px-3 pb-3 d-xl-none">
+                    <a class="@if(!testingStatusPassing){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#testingResults" role="button" aria-expanded="true" aria-controls="testing results" title="Testing Results">@if (!testingStatusPassing)
+                    {<text>Hide Checks</text>}
+                    else
+                    {<text>Show Checks</text>}</a>
+                </div>
+                <div class="collapse @if(!testingStatusPassing){<text>show</text>}" id="testingResults">
+                    <hr class="mt-0" />
+                    @*Validation*@
+                    <div class="px-3">
+                        @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
+                        {
+                            <p class="mb-0"><span class="fas fa-times text-danger mr-3"></span> Validation Testing Failed</p>
+                        }
+                        @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Passing)
+                        {
+                            <p class="mb-0"><span class="fas fa-check text-success mr-3"></span> Validation Testing Passed</p>
+                        }
+                        @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Pending)
+                        {
+                            <p class="mb-0"><span class="fas fa-clock text-warning mr-3"></span> Validation Testing Pending</p>
+                        }
+                        @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Unknown)
+                        {
+                            <p class="mb-0"><span class="fas fa-question text-secondary mr-3"></span> Validation Testing Unknown</p>
+                        }
+                        @if (Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Exempted)
+                        {
+                            <p class="mb-0"><span class="fas fa-ban text-secondary mr-3"></span> Validation Testing Exempt</p>
+                        }
+                    </div>
+                    <hr />
+                    @*Verification*@
+                    <div class="d-flex @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Passing){<text>justify-content-between</text>} px-3 pb-3">
+                        @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
+                        {
+                            <p class="mb-0"><span class="fas fa-times text-danger mr-3"></span> Verification Testing Failed</p>
+                            <a href="@Model.PackageTestResultsUrl" target="_blank" rel="noreferrer">Details</a>
+                        }
+                        @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Passing)
+                        {
+                            <p class="mb-0"><span class="fas fa-check text-success mr-3"></span> Verification Testing Passed</p>
+                            <a href="@Model.PackageTestResultsUrl" target="_blank" rel="noreferrer">Details</a>
+                        }
+                        @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Pending)
+                        {
+                            <p class="mb-0"><span class="fas fa-clock text-warning mr-3"></span> Verification Testing Pending</p>
+                        }
+                        @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Unknown)
+                        {
+                            <p class="mb-0"><span class="fas fa-question text-secondary mr-3"></span> Verification Testing Unknown</p>
+                        }
+                        @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Exempted)
+                        {
+                            <span class="fas fa-ban text-secondary mr-3"></span>
+                            <div>
+                                <p class="mb-0">Verification Testing Exempt:</p>
+                                @Html.Raw(markdownGenerator.Transform(Model.ExemptedFromVerificationReason.clean_html()))
                             </div>
-                            <hr />
-                            @*Verification*@
-                            <div class="d-flex @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Passing){<text>justify-content-between</text>} px-3 pb-3">
-                                @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                {
-                                    <p class="mb-0"><span class="fas fa-times text-danger mr-3"></span> Verification Testing Failed</p>
-                                    <a href="@Model.PackageTestResultsUrl" target="_blank" rel="noreferrer">Details</a>
-                                }
-                                @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Passing)
-                                {
-                                    <p class="mb-0"><span class="fas fa-check text-success mr-3"></span> Verification Testing Passed</p>
-                                    <a href="@Model.PackageTestResultsUrl" target="_blank" rel="noreferrer">Details</a>
-                                }
-                                @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Pending)
-                                {
-                                    <p class="mb-0"><span class="fas fa-clock text-warning mr-3"></span> Verification Testing Pending</p>
-                                }
-                                @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Unknown)
-                                {
-                                    <p class="mb-0"><span class="fas fa-question text-secondary mr-3"></span> Verification Testing Unknown</p>
-                                }
-                                @if (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Exempted)
-                                {
-                                    <span class="fas fa-ban text-secondary mr-3"></span>
-                                    <div>
-                                        <p class="mb-0">Verification Testing Exempt:</p>
-                                        @Html.Raw(markdownGenerator.Transform(Model.ExemptedFromVerificationReason.clean_html()))
-                                    </div>
-                                }
-                            </div>
-                        </div>
+                        }
                     </div>
                 </div>
             </div>
@@ -555,201 +549,199 @@
             {
                 if (Model.Listed || anyPackageRole && Model.Status != PackageStatusType.Rejected)
                 {
-                    <div class="row">
-                        <div class="col-12">
-                            <ul class="nav card-tabs nav-tabs border-bottom-0" role="tablist">
+                    <ul class="nav card-tabs nav-tabs border-bottom-0" role="tablist">
+                        <li class="nav-item">
+                            <a class="nav-link active" id="individual-tab" data-toggle="tab" href="#individual" role="tab" aria-controls="individual" aria-selected="true">Individual</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" id="organization-tab" data-toggle="tab" href="#organization" role="tab" aria-controls="organization" aria-selected="false">Organization</a>
+                        </li>
+                    </ul>
+                    <div class="tab-content bg-white p-3 shadow-sm mb-3 position-relative">
+                        @*Individual*@
+                        <div class="tab-pane fade show active" id="individual" role="tabpanel" aria-labelledby="individual-tab">
+                            <ul class="nav nav-tabs" role="tablist">
                                 <li class="nav-item">
-                                    <a class="nav-link active" id="individual-tab" data-toggle="tab" href="#individual" role="tab" aria-controls="individual" aria-selected="true">Individual</a>
+                                    <a class="nav-link active" id="install-tab" data-toggle="tab" href="#install" role="tab" aria-controls="install" aria-selected="true">Install</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" id="organization-tab" data-toggle="tab" href="#organization" role="tab" aria-controls="organization" aria-selected="false">Organization</a>
+                                    <a class="nav-link" id="upgrade-tab" data-toggle="tab" href="#upgrade" role="tab" aria-controls="upgrade" aria-selected="false">Upgrade</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="uninstall-tab" data-toggle="tab" href="#uninstall" role="tab" aria-controls="uninstall" aria-selected="false">Uninstall</a>
                                 </li>
                             </ul>
-                            <div class="tab-content bg-white p-3 shadow-sm mb-3 position-relative">
-                                @*Individual*@
-                                <div class="tab-pane fade show active" id="individual" role="tabpanel" aria-labelledby="individual-tab">
-                                    <ul class="nav nav-tabs" role="tablist">
-                                        <li class="nav-item">
-                                            <a class="nav-link active" id="install-tab" data-toggle="tab" href="#install" role="tab" aria-controls="install" aria-selected="true">Install</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="upgrade-tab" data-toggle="tab" href="#upgrade" role="tab" aria-controls="upgrade" aria-selected="false">Upgrade</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="uninstall-tab" data-toggle="tab" href="#uninstall" role="tab" aria-controls="uninstall" aria-selected="false">Uninstall</a>
-                                        </li>
-                                    </ul>
-                                    <div class="tab-content p-3">
-                                        <div class="tab-pane fade show active" id="install" role="tabpanel" aria-labelledby="install-tab">
-                                            <p class="mb-3">To install @Model.Title, run the following command from the command line or from PowerShell:</p>
-                                            <div class="input-group copyBox">
-                                                <div class="input-group-prepend">
-                                                    <div class="input-group-text">></div>
-                                                </div>
-                                                <input type="text" class="form-control"
-                                                       value="choco install @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
-                                                       aria-label="Install @Model.Title command"
-                                                       readonly>
-                                                <div class="input-group-append">
-                                                    <button class="btn btn-primary tt"
-                                                            aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
-                                                            data-toggle="tooltip"
-                                                            title="Copy to Clipboard"
-                                                            data-clipboard-text="choco install @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
-                                                        <i class="fas fa-clipboard" aria-hidden="true">
-                                                            <span class="sr-only">
-                                                                Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
-                                                                {<text> --version @Model.Version</text>} @if (Model.Prerelease)
-                                                                {<text> --pre </text>} to Clipboard
-                                                            </span>
-                                                        </i>
-                                                    </button>
-                                                </div>
-                                            </div>
+                            <div class="tab-content p-3">
+                                <div class="tab-pane fade show active" id="install" role="tabpanel" aria-labelledby="install-tab">
+                                    <p class="mb-3">To install @Model.Title, run the following command from the command line or from PowerShell:</p>
+                                    <div class="input-group copyBox">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">></div>
                                         </div>
-                                        <div class="tab-pane fade" id="upgrade" role="tabpanel" aria-labelledby="upgrade-tab">
-                                            <p class="mb-3">To upgrade @Model.Title, run the following command from the command line or from PowerShell:</p>
-                                            <div class="input-group copyBox">
-                                                <div class="input-group-prepend">
-                                                    <div class="input-group-text">></div>
-                                                </div>
-                                                <input type="text" class="form-control"
-                                                       value="choco upgrade @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
-                                                       aria-label="Upgrade @Model.Title command"
-                                                       readonly>
-                                                <div class="input-group-append">
-                                                    <button class="btn btn-primary tt"
-                                                            aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
-                                                            data-toggle="tooltip"
-                                                            title="Copy to Clipboard"
-                                                            data-clipboard-text="choco upgrade @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
-                                                        <i class="fas fa-clipboard" aria-hidden="true">
-                                                            <span class="sr-only">
-                                                                Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
-                                                                {<text> --version @Model.Version</text>} @if (Model.Prerelease)
-                                                                {<text> --pre </text>} to Clipboard
-                                                            </span>
-                                                        </i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="tab-pane fade" id="uninstall" role="tabpanel" aria-labelledby="uninstall-tab">
-                                            <p class="mb-3">To uninstall @Model.Title, run the following command from the command line or from PowerShell:</p>
-                                            <div class="input-group copyBox">
-                                                <div class="input-group-prepend">
-                                                    <div class="input-group-text">></div>
-                                                </div>
-                                                <input type="text" class="form-control"
-                                                       value="choco uninstall @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
-                                                       aria-label="Uninstall @Model.Title command"
-                                                       readonly>
-                                                <div class="input-group-append">
-                                                    <button class="btn btn-primary tt"
-                                                            aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
-                                                            data-toggle="tooltip"
-                                                            title="Copy to Clipboard"
-                                                            data-clipboard-text="choco uninstall @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
-                                                        <i class="fas fa-clipboard" aria-hidden="true">
-                                                            <span class="sr-only">
-                                                                Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
-                                                                {<text> --version @Model.Version</text>} @if (Model.Prerelease)
-                                                                {<text> --pre </text>} to Clipboard
-                                                            </span>
-                                                        </i>
-                                                    </button>
-                                                </div>
-                                            </div>
+                                        <input type="text" class="form-control"
+                                                value="choco install @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
+                                                aria-label="Install @Model.Title command"
+                                                readonly>
+                                        <div class="input-group-append">
+                                            <button class="btn btn-primary tt"
+                                                    aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
+                                                    data-toggle="tooltip"
+                                                    title="Copy to Clipboard"
+                                                    data-clipboard-text="choco install @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
+                                                <i class="fas fa-clipboard" aria-hidden="true">
+                                                    <span class="sr-only">
+                                                        Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
+                                                        {<text> --version @Model.Version</text>} @if (Model.Prerelease)
+                                                        {<text> --pre </text>} to Clipboard
+                                                    </span>
+                                                </i>
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
-                                @*Organizational*@
-                                <div class="tab-pane fade" id="organization" role="tabpanel" aria-labelledby="organization-tab">
-                                  <p class="small font-weight-bold">NOTE: This applies to both open source and commercial editions of Chocolatey.</p>
-                                    @*Step 1*@
-                                    <h4>1. Ensure you are set for organizational deployment</h4>
-                                    <p>Please see the <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "how-to-setup-offline-installation" })">organizational deployment guide</a></p>
-                                    @*Step 2*@
-                                    <a class="h4 collapsed d-block" data-toggle="collapse" href="#install-step2" role="button" aria-expanded="false" aria-controls="install-step2" title="Install Step 2">2. Get the package into your environment</a>
-                                    <div class="collapse" id="install-step2">
-                                        <div class="p-3">
-                                            @*Option 1*@
-                                            <a class="h5 collapsed d-block" data-toggle="collapse" href="#install-step2-option1" role="button" aria-expanded="false" aria-controls="install-step2-option1" title="Install Step 2 Option 1">Option 1: Cached Package (Unreliable, Requires Internet - Same As Community)</a>
-                                            <div class="collapse" id="install-step2-option1">
-                                                <ul>
-                                                    <li>
-                                                        Open Source or Commercial:
-                                                        <ul>
-                                                            <li>Proxy Repository - Create a proxy nuget repository on Nexus, Artifactory Pro, or a proxy Chocolatey repository on ProGet. Point your upstream to <strong>https://chocolatey.org/api/v2</strong>. Packages cache on first access automatically. Make sure your choco clients are using your proxy repository as a source and NOT the default community repository. See <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "commands-sources"})">source command</a> for more information.</li>
-                                                            <li>You can also just download the package and push it to a repository <a class="btn btn-secondary btn-sm" href="@Url.PackageDownload(2, Model.Id, Model.Version)" title="Download the raw nupkg file." download><i class="fas fa-download" alt="Download"></i> Download</a></li>
-                                                        </ul>
-                                                    </li>
-                                                </ul>
-                                            </div>
-                                            @*Option 2*@
-                                            <a class="h5 mt-3 collapsed d-block" data-toggle="collapse" href="#install-step2-option2" role="button" aria-expanded="false" aria-controls="install-step2-option1" title="Install Step 2 Option 2">Option 2: Internalized Package (Reliable, Scalable)</a>
-                                            <div class="collapse" id="install-step2-option2">
-                                                <ul>
-                                                    <li>
-                                                        Open Source
-                                                        <ul>
-                                                            <li>Download the Package <a class="btn btn-secondary btn-sm" href="@Url.PackageDownload(2, Model.Id, Model.Version)" title="Download the raw nupkg file." download><i class="fas fa-download" alt="Download"></i> Download</a></li>
-                                                            <li><a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-recompile-packages"})">Follow manual internalization instructions</a></li>
-                                                        </ul>
-                                                    </li>
-                                                    <li>
-                                                        Package Internalizer (C4B)
-                                                        <ul>
-                                                            <li>Run <code>choco download @Model.Id.ToLower() --internalize @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed){<text> --version=@Model.Version</text>} --source=https://chocolatey.org/api/v2</code> <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-download" })">(additional options)</a></li>
-                                                            <li>Run <code>choco push --source=&quot;'http://internal/odata/repo'&quot;</code> for package and dependencies</li>
-                                                            <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "how-to-setup-internal-package-repository" })">Automate package internalization</a></li>
-                                                        </ul>
-                                                    </li>
-                                                </ul>
-                                            </div>
+                                <div class="tab-pane fade" id="upgrade" role="tabpanel" aria-labelledby="upgrade-tab">
+                                    <p class="mb-3">To upgrade @Model.Title, run the following command from the command line or from PowerShell:</p>
+                                    <div class="input-group copyBox">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">></div>
+                                        </div>
+                                        <input type="text" class="form-control"
+                                                value="choco upgrade @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
+                                                aria-label="Upgrade @Model.Title command"
+                                                readonly>
+                                        <div class="input-group-append">
+                                            <button class="btn btn-primary tt"
+                                                    aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
+                                                    data-toggle="tooltip"
+                                                    title="Copy to Clipboard"
+                                                    data-clipboard-text="choco upgrade @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
+                                                <i class="fas fa-clipboard" aria-hidden="true">
+                                                    <span class="sr-only">
+                                                        Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
+                                                        {<text> --version @Model.Version</text>} @if (Model.Prerelease)
+                                                        {<text> --pre </text>} to Clipboard
+                                                    </span>
+                                                </i>
+                                            </button>
                                         </div>
                                     </div>
-                                    @*Step 3*@
-                                    <h4 class="mt-4">3. Enter your internal repository url</h4>
-                                    <input class="form-control w-50" id="stepThreeUrl" type="text" placeholder="http://internal/odata/repo" />
-                                    <p><small>(this should look similar to <a href="https://chocolatey.org/api/v2">https://chocolatey.org/api/v2</a>)</small></p>
-                                    @*Step 4*@
-                                    <h4 class="mt-4">4. Choose your deployment method:</h4>
-                                    <ul class="nav nav-tabs" role="tablist">
-                                        <li class="nav-item">
-                                            <a class="nav-link active" id="generic-tab" data-toggle="tab" href="#generic" role="tab" aria-controls="generic" aria-selected="false">Generic</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="ansible-tab" data-toggle="tab" href="#ansible" role="tab" aria-controls="ansible" aria-selected="false">Ansible</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="ccm-tab" data-toggle="tab" href="#ccm" role="tab" aria-controls="ccm" aria-selected="false">Central Management</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="chef-tab" data-toggle="tab" href="#chef" role="tab" aria-controls="chef" aria-selected="false">Chef</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="otter-tab" data-toggle="tab" href="#otter" role="tab" aria-controls="otter" aria-selected="false">Otter</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="psdsc-tab" data-toggle="tab" href="#psdsc" role="tab" aria-controls="psdsc" aria-selected="false">PS DSC</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="puppet-tab" data-toggle="tab" href="#puppet" role="tab" aria-controls="puppet" aria-selected="false">Puppet</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link" id="salt-tab" data-toggle="tab" href="#salt" role="tab" aria-controls="salt" aria-selected="false">Salt</a>
-                                        </li>
-                                    </ul>
-                                    <div class="tab-content stepThree p-3">
-                                        <div class="tab-pane fade show active" id="generic" role="tabpanel" aria-labelledby="generic-tab">
+                                </div>
+                                <div class="tab-pane fade" id="uninstall" role="tabpanel" aria-labelledby="uninstall-tab">
+                                    <p class="mb-3">To uninstall @Model.Title, run the following command from the command line or from PowerShell:</p>
+                                    <div class="input-group copyBox">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">></div>
+                                        </div>
+                                        <input type="text" class="form-control"
+                                                value="choco uninstall @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}"
+                                                aria-label="Uninstall @Model.Title command"
+                                                readonly>
+                                        <div class="input-group-append">
+                                            <button class="btn btn-primary tt"
+                                                    aria-label="Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>} to Clipboard"
+                                                    data-toggle="tooltip"
+                                                    title="Copy to Clipboard"
+                                                    data-clipboard-text="choco uninstall @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed) {<text> --version=@Model.Version</text>} @if (Model.Prerelease) {<text> --pre </text>}">
+                                                <i class="fas fa-clipboard" aria-hidden="true">
+                                                    <span class="sr-only">
+                                                        Copy @Model.Id.ToLower() @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed)
+                                                        {<text> --version @Model.Version</text>} @if (Model.Prerelease)
+                                                        {<text> --pre </text>} to Clipboard
+                                                    </span>
+                                                </i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        @*Organizational*@
+                        <div class="tab-pane fade" id="organization" role="tabpanel" aria-labelledby="organization-tab">
+                            <p class="small font-weight-bold">NOTE: This applies to both open source and commercial editions of Chocolatey.</p>
+                            @*Step 1*@
+                            <h4>1. Ensure you are set for organizational deployment</h4>
+                            <p>Please see the <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "how-to-setup-offline-installation" })">organizational deployment guide</a></p>
+                            @*Step 2*@
+                            <a class="h4 collapsed d-block" data-toggle="collapse" href="#install-step2" role="button" aria-expanded="false" aria-controls="install-step2" title="Install Step 2">2. Get the package into your environment</a>
+                            <div class="collapse" id="install-step2">
+                                <div class="p-3">
+                                    @*Option 1*@
+                                    <a class="h5 collapsed d-block" data-toggle="collapse" href="#install-step2-option1" role="button" aria-expanded="false" aria-controls="install-step2-option1" title="Install Step 2 Option 1">Option 1: Cached Package (Unreliable, Requires Internet - Same As Community)</a>
+                                    <div class="collapse" id="install-step2-option1">
+                                        <ul>
+                                            <li>
+                                                Open Source or Commercial:
+                                                <ul>
+                                                    <li>Proxy Repository - Create a proxy nuget repository on Nexus, Artifactory Pro, or a proxy Chocolatey repository on ProGet. Point your upstream to <strong>https://chocolatey.org/api/v2</strong>. Packages cache on first access automatically. Make sure your choco clients are using your proxy repository as a source and NOT the default community repository. See <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "commands-sources"})">source command</a> for more information.</li>
+                                                    <li>You can also just download the package and push it to a repository <a class="btn btn-secondary btn-sm" href="@Url.PackageDownload(2, Model.Id, Model.Version)" title="Download the raw nupkg file." download><i class="fas fa-download" alt="Download"></i> Download</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                    @*Option 2*@
+                                    <a class="h5 mt-3 collapsed d-block" data-toggle="collapse" href="#install-step2-option2" role="button" aria-expanded="false" aria-controls="install-step2-option1" title="Install Step 2 Option 2">Option 2: Internalized Package (Reliable, Scalable)</a>
+                                    <div class="collapse" id="install-step2-option2">
+                                        <ul>
+                                            <li>
+                                                Open Source
+                                                <ul>
+                                                    <li>Download the Package <a class="btn btn-secondary btn-sm" href="@Url.PackageDownload(2, Model.Id, Model.Version)" title="Download the raw nupkg file." download><i class="fas fa-download" alt="Download"></i> Download</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-recompile-packages"})">Follow manual internalization instructions</a></li>
+                                                </ul>
+                                            </li>
+                                            <li>
+                                                Package Internalizer (C4B)
+                                                <ul>
+                                                    <li>Run <code>choco download @Model.Id.ToLower() --internalize @if ((!Model.LatestVersion && !Model.LatestStableVersion) || !Model.Listed){<text> --version=@Model.Version</text>} --source=https://chocolatey.org/api/v2</code> <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-download" })">(additional options)</a></li>
+                                                    <li>Run <code>choco push --source=&quot;'http://internal/odata/repo'&quot;</code> for package and dependencies</li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "how-to-setup-internal-package-repository" })">Automate package internalization</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            @*Step 3*@
+                            <h4 class="mt-4">3. Enter your internal repository url</h4>
+                            <input class="form-control w-50" id="stepThreeUrl" type="text" placeholder="http://internal/odata/repo" />
+                            <p><small>(this should look similar to <a href="https://chocolatey.org/api/v2">https://chocolatey.org/api/v2</a>)</small></p>
+                            @*Step 4*@
+                            <h4 class="mt-4">4. Choose your deployment method:</h4>
+                            <ul class="nav nav-tabs" role="tablist">
+                                <li class="nav-item">
+                                    <a class="nav-link active" id="generic-tab" data-toggle="tab" href="#generic" role="tab" aria-controls="generic" aria-selected="false">Generic</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="ansible-tab" data-toggle="tab" href="#ansible" role="tab" aria-controls="ansible" aria-selected="false">Ansible</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="ccm-tab" data-toggle="tab" href="#ccm" role="tab" aria-controls="ccm" aria-selected="false">Central Management</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="chef-tab" data-toggle="tab" href="#chef" role="tab" aria-controls="chef" aria-selected="false">Chef</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="otter-tab" data-toggle="tab" href="#otter" role="tab" aria-controls="otter" aria-selected="false">Otter</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="psdsc-tab" data-toggle="tab" href="#psdsc" role="tab" aria-controls="psdsc" aria-selected="false">PS DSC</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="puppet-tab" data-toggle="tab" href="#puppet" role="tab" aria-controls="puppet" aria-selected="false">Puppet</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" id="salt-tab" data-toggle="tab" href="#salt" role="tab" aria-controls="salt" aria-selected="false">Salt</a>
+                                </li>
+                            </ul>
+                            <div class="tab-content stepThree p-3">
+                                <div class="tab-pane fade show active" id="generic" role="tabpanel" aria-labelledby="generic-tab">
 <pre class="language-powershell border py-3"><code>
 choco upgrade @Model.Id.ToLower() -y --source=&quot;'STEP 3 URL'&quot; [other options]
 </code></pre>
-                                            <p class="mt-3">See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-upgrade" })#options-and-switches">options you can pass to upgrade.</a></p>
-                                            <p>See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-reference" })#scripting-integration-best-practices-style-guide">best practices for scripting.</a></p>
-                                            <p>Add this to a PowerShell script or use a Batch script with tools and in places where you are calling directly to Chocolatey. If you are integrating, keep in mind enhanced exit codes.</p>
-                                            <p>If you do use a PowerShell script, use the following to ensure bad exit codes are shown as failures:</p>
+                                    <p class="mt-3">See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-upgrade" })#options-and-switches">options you can pass to upgrade.</a></p>
+                                    <p>See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-reference" })#scripting-integration-best-practices-style-guide">best practices for scripting.</a></p>
+                                    <p>Add this to a PowerShell script or use a Batch script with tools and in places where you are calling directly to Chocolatey. If you are integrating, keep in mind enhanced exit codes.</p>
+                                    <p>If you do use a PowerShell script, use the following to ensure bad exit codes are shown as failures:</p>
 <pre class="language-powershell line-numbers border py-3"><code>
 choco upgrade @Model.Id.ToLower() -y --source="'STEP 3 URL'" 
 $exitCode = $LASTEXITCODE
@@ -762,8 +754,8 @@ if ($validExitCodes -contains $exitCode) {
 
 Exit $exitCode
 </code></pre>
-                                        </div>
-                                        <div class="tab-pane fade" id="ansible" role="tabpanel" aria-labelledby="ansible-tab">
+                                </div>
+                                <div class="tab-pane fade" id="ansible" role="tabpanel" aria-labelledby="ansible-tab">
 <pre class="language-yaml line-numbers border py-3"><code>
 - name: Ensure @Model.Id.ToLower() installed
   win_chocolatey:
@@ -772,12 +764,12 @@ Exit $exitCode
     version: @Model.Version
     source: STEP 3 URL
 </code></pre>
-                                            <p>See docs at <a href="https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html" target="_blank" rel="noreferrer">https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html</a>.</p>
-                                        </div>
-                                        <div class="tab-pane fade" id="ccm" role="tabpanel" aria-labelledby="ccm-tab">
-                                            <p>Coming early 2020! Central Managment Reporting available now! <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-chocolatey-central-management" })">More information...</a></p>
-                                        </div>
-                                        <div class="tab-pane fade" id="chef" role="tabpanel" aria-labelledby="chef-tab">
+                                    <p>See docs at <a href="https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html" target="_blank" rel="noreferrer">https://docs.ansible.com/ansible/latest/modules/win_chocolatey_module.html</a>.</p>
+                                </div>
+                                <div class="tab-pane fade" id="ccm" role="tabpanel" aria-labelledby="ccm-tab">
+                                    <p>Coming early 2020! Central Managment Reporting available now! <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-chocolatey-central-management" })">More information...</a></p>
+                                </div>
+                                <div class="tab-pane fade" id="chef" role="tabpanel" aria-labelledby="chef-tab">
 <pre class="language-ruby line-numbers border py-3"><code>
 chocolatey_package '@Model.Id.ToLower()' do
   action    :install
@@ -785,9 +777,9 @@ chocolatey_package '@Model.Id.ToLower()' do
   source   'STEP 3 URL'
 end
 </code></pre>
-                                            <p>See docs at <a href="https://docs.chef.io/resource_chocolatey_package.html" target="_blank" rel="noreferrer">https://docs.chef.io/resource_chocolatey_package.html</a>.</p>
-                                        </div>
-                                        <div class="tab-pane fade" id="otter" role="tabpanel" aria-labelledby="otter-tab">
+                                    <p>See docs at <a href="https://docs.chef.io/resource_chocolatey_package.html" target="_blank" rel="noreferrer">https://docs.chef.io/resource_chocolatey_package.html</a>.</p>
+                                </div>
+                                <div class="tab-pane fade" id="otter" role="tabpanel" aria-labelledby="otter-tab">
 <pre class="language-powershell line-numbers border py-3"><code>
 Chocolatey::Ensure-Package
 (
@@ -796,9 +788,9 @@ Chocolatey::Ensure-Package
     Source: STEP 3 URL
 );
 </code></pre>
-                                            <p>Requires Otter Chocolatey Extension. See docs at <a href="https://inedo.com/den/otter/chocolatey" target="_blank" rel="noreferrer">https://inedo.com/den/otter/chocolatey</a>.</p>
-                                        </div>
-                                        <div class="tab-pane fade" id="psdsc" role="tabpanel" aria-labelledby="psdsc-tab">
+                                    <p>Requires Otter Chocolatey Extension. See docs at <a href="https://inedo.com/den/otter/chocolatey" target="_blank" rel="noreferrer">https://inedo.com/den/otter/chocolatey</a>.</p>
+                                </div>
+                                <div class="tab-pane fade" id="psdsc" role="tabpanel" aria-labelledby="psdsc-tab">
 <pre class="language-powershell line-numbers border py-3"><code>
 cChocoPackageInstaller @Model.Id.ToLower()
 {
@@ -808,9 +800,9 @@ cChocoPackageInstaller @Model.Id.ToLower()
    Source   = 'STEP 3 URL'
 }
 </code></pre>
-                                            <p>Requires cChoco DSC Resource. See docs at <a href="https://github.com/chocolatey/cChoco" target="_blank" rel="noreferrer">https://github.com/chocolatey/cChoco</a>.</p>
-                                        </div>
-                                        <div class="tab-pane fade" id="puppet" role="tabpanel" aria-labelledby="puppet-tab">
+                                    <p>Requires cChoco DSC Resource. See docs at <a href="https://github.com/chocolatey/cChoco" target="_blank" rel="noreferrer">https://github.com/chocolatey/cChoco</a>.</p>
+                                </div>
+                                <div class="tab-pane fade" id="puppet" role="tabpanel" aria-labelledby="puppet-tab">
 <pre class="language-puppet line-numbers border py-3"><code>
 package { '@Model.Id.ToLower()':
   provider => 'chocolatey',
@@ -818,20 +810,18 @@ package { '@Model.Id.ToLower()':
   source   => 'STEP 3 URL',
 }
 </code></pre>
-                                            <p>Requires Puppet Chocolatey Provider module. See docs at <a href="https://forge.puppet.com/puppetlabs/chocolatey" target="_blank" rel="noreferrer">https://forge.puppet.com/puppetlabs/chocolatey</a>.</p>
-                                        </div>
-                                        <div class="tab-pane fade" id="salt" role="tabpanel" aria-labelledby="salt-tab">
+                                    <p>Requires Puppet Chocolatey Provider module. See docs at <a href="https://forge.puppet.com/puppetlabs/chocolatey" target="_blank" rel="noreferrer">https://forge.puppet.com/puppetlabs/chocolatey</a>.</p>
+                                </div>
+                                <div class="tab-pane fade" id="salt" role="tabpanel" aria-labelledby="salt-tab">
 <pre class="language-powershell line-numbers border py-3"><code>
 salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source="STEP 3 URL"
 </code></pre>
-                                            <p>See docs at <a href="https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html" target="_blank" rel="noreferrer">https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html</a>.</p>
-                                        </div>
-                                    </div>
-                                    @*Step 5*@
-                                    <h4 class="mt-4">5. If applicable - Chocolatey configuration/installation</h4>
-                                    <p>See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-infrastructure-automation" })#chocolatey-integration-implementation-with-common-configuration-managers">infrastructure management matrix</a> for Chocolatey configuration elements and examples.</p>
+                                    <p>See docs at <a href="https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html" target="_blank" rel="noreferrer">https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.chocolatey.html</a>.</p>
                                 </div>
                             </div>
+                            @*Step 5*@
+                            <h4 class="mt-4">5. If applicable - Chocolatey configuration/installation</h4>
+                            <p>See <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-infrastructure-automation" })#chocolatey-integration-implementation-with-common-configuration-managers">infrastructure management matrix</a> for Chocolatey configuration elements and examples.</p>
                         </div>
                     </div>
                 }
@@ -868,336 +858,329 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                 </div>
             }
             @*  Package Status & Notices *@
-            <div class="row">
-                <div class="col-12">
-                    @if (Model.IsDownloadCacheAvailable)
-                    {
-                        <div class="callout callout-secondary">
-                            <p>Private CDN cached downloads available for licensed customers. Never experience 404 breakages again! <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-private-cdn" })">Learn more...</a></p>
+            @if (Model.IsDownloadCacheAvailable)
+            {
+                <div class="callout callout-secondary">
+                    <p>Private CDN cached downloads available for licensed customers. Never experience 404 breakages again! <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-private-cdn" })">Learn more...</a></p>
+                </div>
+            }
+            @if (Model.IsInstallOrPortable)
+            {
+                <div class="callout callout-primary">
+                    <p>This package is likely a meta/virtual (*) or an installer (*.install) or portable (*.portable) application package.</p>
+                    <ul>
+                        <li>Meta/virtual (*) - has a dependency on the *.install or the *.portable package - it is provided for discoverability and for other packages to take a dependency on.</li>
+                        <li>Portable (*.portable/*.commandline (deprecated naming convention)/*.tool (deprecated naming convention)) - usually zips or archives that require no administrative access to install.</li>
+                        <li>Install (*.install/*.app (deprecated naming convention)) - uses native installers, usually requires administrative access to install.</li>
+                    </ul>
+                    <p></p>
+                    <p>Learn more about chocolatey's distinction of <a href="@Url.RouteUrl(RouteName.FAQ)#what-distinction-does-chocolatey-make-between-an-installable-and-a-portable-application">installed versus portable apps</a> and/or learn about <a href="@Url.RouteUrl(RouteName.FAQ)#what-is-the-difference-between-packages-named-install-ie-autohotkeyinstall-portable-ie-autohotkeyportable-and--ie-autohotkey">this kind of package</a>.</p>
+                </div>
+            }
+            @if (Model.Status == PackageStatusType.Submitted && !anyPackageRole)
+            {
+                <div class="callout callout-danger">
+                    <p>This version is in <a href="@Url.RouteUrl(RouteName.FAQ)#what-is-moderation">moderation</a> and has not yet been approved. This means it doesn't show up under normal search.</p>
+                    <ul class="mb-0">
+                        <li>Until approved, you should consider this package version unsafe - it could do very bad things to your system (it probably doesn't but you have been warned, that's why we have moderation).</li>
+                        <li>This package version can change wildly over the course of moderation until it is approved. If you install it and it later has changes to this version, you will be out of sync with any changes that have been made to the package. Until approved, you should consider that this package version doesn't even exist.</li>
+                        <li>You cannot install this package under normal scenarios. See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-install-a-package-version-under-moderation">How to install package version under moderation</a> for more information.</li>
+                        <li>There are also no guarantees that it will be approved.</li>
+                    </ul>
+                </div>
+            }
+            @if (Model.PackageVersions.Any(pv => pv.Status == PackageStatusType.Submitted))
+            {
+                <div class="callout callout-warning">
+                    <p>There are versions of this package awaiting moderation @(Model.Status == PackageStatusType.Submitted ? "(possibly just this one)" : string.Empty). See the <a href="#versionhistory">Version History section</a> below.</p>
+                </div>
+            }
+            @if (Model.Status == PackageStatusType.Rejected)
+            {
+                <div class="callout callout-danger">
+                    <p>This package was rejected on @Model.ReviewedDate.GetValueOrDefault().ToShortDateString(). The reviewer @Model.ReviewerUserName has listed the following reason(s):</p>
+                    <div class="comments-list-container">
+                        <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text >user-unknown</text>}">
+                            @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
                         </div>
-                    }
-                    @if (Model.IsInstallOrPortable)
+                    </div>
+                </div>
+            }
+            else if (maintainer && !Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
+            {
+                <div class="callout callout-danger">
+                    <p>
+                        This package will remain unlisted until it has been approved by a moderator.
+                        You can see the package because you are one of its maintainers. You should have received an email about moderation. If you need to update/respond to the package review, please do so in the form below. If you need to contact the moderators for other reasons, feel free to respond to the email you received.
+                        If you have not received that email, please <a href="@Url.RouteUrl(RouteName.PackageVersionAction, new { action = "ContactAdmins", id = Model.Id, version = Model.Version })" title="Contact Site Admins">contact Site Admins</a>.
+                    </p>
+                    @if (moderationRoleAndMaintaner)
                     {
-                        <div class="callout callout-primary">
-                            <p>This package is likely a meta/virtual (*) or an installer (*.install) or portable (*.portable) application package.</p>
-                            <ul>
-                                <li>Meta/virtual (*) - has a dependency on the *.install or the *.portable package - it is provided for discoverability and for other packages to take a dependency on.</li>
-                                <li>Portable (*.portable/*.commandline (deprecated naming convention)/*.tool (deprecated naming convention)) - usually zips or archives that require no administrative access to install.</li>
-                                <li>Install (*.install/*.app (deprecated naming convention)) - uses native installers, usually requires administrative access to install.</li>
-                            </ul>
-                            <p></p>
-                            <p>Learn more about chocolatey's distinction of <a href="@Url.RouteUrl(RouteName.FAQ)#what-distinction-does-chocolatey-make-between-an-installable-and-a-portable-application">installed versus portable apps</a> and/or learn about <a href="@Url.RouteUrl(RouteName.FAQ)#what-is-the-difference-between-packages-named-install-ie-autohotkeyinstall-portable-ie-autohotkeyportable-and--ie-autohotkey">this kind of package</a>.</p>
-                        </div>
+                        <p>Since you are a maintainer of this package, you are not able to review it.</p>
                     }
-                    @if (Model.Status == PackageStatusType.Submitted && !anyPackageRole)
-                    {
-                        <div class="callout callout-danger">
-                            <p>This version is in <a href="@Url.RouteUrl(RouteName.FAQ)#what-is-moderation">moderation</a> and has not yet been approved. This means it doesn't show up under normal search.</p>
-                            <ul class="mb-0">
-                                <li>Until approved, you should consider this package version unsafe - it could do very bad things to your system (it probably doesn't but you have been warned, that's why we have moderation).</li>
-                                <li>This package version can change wildly over the course of moderation until it is approved. If you install it and it later has changes to this version, you will be out of sync with any changes that have been made to the package. Until approved, you should consider that this package version doesn't even exist.</li>
-                                <li>You cannot install this package under normal scenarios. See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-install-a-package-version-under-moderation">How to install package version under moderation</a> for more information.</li>
-                                <li>There are also no guarantees that it will be approved.</li>
-                            </ul>
-                        </div>
-                    }
-                    @if (Model.PackageVersions.Any(pv => pv.Status == PackageStatusType.Submitted))
-                    {
-                        <div class="callout callout-warning">
-                            <p>There are versions of this package awaiting moderation @(Model.Status == PackageStatusType.Submitted ? "(possibly just this one)" : string.Empty). See the <a href="#versionhistory">Version History section</a> below.</p>
-                        </div>
-                    }
-                    @if (Model.Status == PackageStatusType.Rejected)
-                    {
-                        <div class="callout callout-danger">
-                            <p>This package was rejected on @Model.ReviewedDate.GetValueOrDefault().ToShortDateString(). The reviewer @Model.ReviewerUserName has listed the following reason(s):</p>
-                            <div class="comments-list-container">
-                                <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text >user-unknown</text>}">
-                                    @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
-                                </div>
+                </div>
+            }
+            else if (maintainer && !Model.Listed)
+            {
+                <div class="callout callout-warning">
+                    This package is unlisted and hidden from package listings.
+                    You can see the package because you are one of its maintainers. To list the package
+                    again, <a href="@Url.DeletePackage(Model)">change its listing setting</a> (does not apply to unapproved packages).
+                </div>
+            }
+            else if (!Model.Listed && Model.Status != PackageStatusType.Submitted)
+            {
+                <div class="callout callout-warning">
+                    This package is unlisted and hidden from package listings.
+                </div>
+            }
+            @* Maintainers always see the review comments *@
+            @if (Model.Status == PackageStatusType.Approved)
+            {
+                <div class="callout callout-success">
+                    <p>This package was approved @Html.Raw(@reviewerComments) on @Model.ApprovedDate.GetValueOrDefault().ToShortDateString().</p>
+                </div>
+            }
+            @if (Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
+            {
+                <div class="callout callout-danger">
+                    <p>This package was submitted prior to moderation and has not been approved. While it is likely safe for you, there is more risk involved.</p>
+                </div>
+            }
+            @if (Model.Listed && Model.Status == PackageStatusType.Exempted)
+            {
+                <div class="callout callout-danger">
+                    This package is exempt from moderation. While it is likely safe for you, there is more risk involved.
+                </div>
+            }
+            @if (Model.Status == PackageStatusType.Submitted && !anyPackageRole)
+            {
+                if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
+                {
+                    @*Not logged in moderator que*@
+                    <div class="bg-white shadow-sm p-3 mb-3">
+                        <div class="comments-list-container">
+                            <div class="comments-list user-unknown">
+                                @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
                             </div>
                         </div>
-                    }
-                    else if (maintainer && !Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
-                    {
-                        <div class="callout callout-danger">
-                            <p>
-                                This package will remain unlisted until it has been approved by a moderator.
-                                You can see the package because you are one of its maintainers. You should have received an email about moderation. If you need to update/respond to the package review, please do so in the form below. If you need to contact the moderators for other reasons, feel free to respond to the email you received.
-                                If you have not received that email, please <a href="@Url.RouteUrl(RouteName.PackageVersionAction, new { action = "ContactAdmins", id = Model.Id, version = Model.Version })" title="Contact Site Admins">contact Site Admins</a>.
-                            </p>
-                            @if (moderationRoleAndMaintaner)
-                            {
-                                <p>Since you are a maintainer of this package, you are not able to review it.</p>
-                            }
-                        </div>
-                    }
-                    else if (maintainer && !Model.Listed)
-                    {
-                        <div class="callout callout-warning">
-                            This package is unlisted and hidden from package listings.
-                            You can see the package because you are one of its maintainers. To list the package
-                            again, <a href="@Url.DeletePackage(Model)">change its listing setting</a> (does not apply to unapproved packages).
-                        </div>
-                    }
-                    else if (!Model.Listed && Model.Status != PackageStatusType.Submitted)
-                    {
-                        <div class="callout callout-warning">
-                            This package is unlisted and hidden from package listings.
-                        </div>
-                    }
-                    @* Maintainers always see the review comments *@
-                    @if (Model.Status == PackageStatusType.Approved)
-                    {
-                        <div class="callout callout-success">
-                            <p>This package was approved @Html.Raw(@reviewerComments) on @Model.ApprovedDate.GetValueOrDefault().ToShortDateString().</p>
-                        </div>
-                    }
-                    @if (Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
-                    {
-                        <div class="callout callout-danger">
-                            <p>This package was submitted prior to moderation and has not been approved. While it is likely safe for you, there is more risk involved.</p>
-                        </div>
-                    }
-                    @if (Model.Listed && Model.Status == PackageStatusType.Exempted)
-                    {
-                        <div class="callout callout-danger">
-                            This package is exempt from moderation. While it is likely safe for you, there is more risk involved.
-                        </div>
-                    }
-                    @if (Model.Status == PackageStatusType.Submitted && !anyPackageRole)
-                    {
-                        if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
-                        {
-                            @*Not logged in moderator que*@
-                            <div class="bg-white shadow-sm p-3 mb-3">
-                                <div class="comments-list-container">
-                                    <div class="comments-list user-unknown">
-                                        @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
-                                    </div>
-                                </div>
-                            </div>
-                        }
-                    }
-                    @*Logged in*@
-                    else if (anyPackageRole && Model.Status != PackageStatusType.Rejected)
-                    {
-                        if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
-                        {
+                    </div>
+                }
+            }
+            @*Logged in*@
+            else if (anyPackageRole && Model.Status != PackageStatusType.Rejected)
+            {
+                if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
+                {
 
-                            <div class="bg-white shadow-sm p-3 mb-3">
-                                <div class="comments-list-container">
-                                    <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text> user-unknown</text>}">
-                                        @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
-                                    </div>
-                                </div>
-                                @if (anyPackageRole)
+                    <div class="bg-white shadow-sm p-3 mb-3">
+                        <div class="comments-list-container">
+                            <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text> user-unknown</text>}">
+                                @Html.Raw(markdownGenerator.Transform(Model.ReviewComments.clean_html()))
+                            </div>
+                        </div>
+                        @if (anyPackageRole)
+                        {
+                            if (Model.Listed || Model.Status == PackageStatusType.Rejected)
+                            {
+                                if (Model.Status == PackageStatusType.Approved)
                                 {
-                                    if (Model.Listed || Model.Status == PackageStatusType.Rejected)
-                                    {
-                                        if (Model.Status == PackageStatusType.Approved)
+                                    <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Show Package Communication / Package Test Rerun</button>
+                                }
+                                else
+                                {
+                                    <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Hide Package Review</button>
+                                }
+                            }
+                            <div class="collapse @if (anyPackageRole && Model.Status != PackageStatusType.Approved) {<text>show</text>} " id="add-comment">
+                                @if (moderationRole)
+                                {
+                                    <hr />
+                                    <h3 class="mt-3">Instructions for Review:</h3>
+                                    <ul>
+                                        <li>Reviewers/Moderators must follow review process at <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "moderation" })#reviewer--moderator-process">moderation</a>.
+                                        <li>**Please do not reject a package until the end of the conversation.**</li>
+                                        <li>Check over the powershell scripts - anything look unsafe? Download urls should be official distro</li>
+                                        @if (Model.Status == PackageStatusType.Approved || Model.Status == PackageStatusType.Exempted)
                                         {
-                                            <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Show Package Communication / Package Test Rerun</button>
+                                            <li>Moderators: Be very careful about moving a package from approved/exempt into submitted status. A package may be repushed when in this status (no matter how many downloads).</li>
                                         }
-                                        else
+                                        @if (Model.Dependencies.DependencySets.Any())
                                         {
-                                            <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Hide Package Review</button>
+                                            <li>Check dependencies, make sure they are listed on the site (approved if they needed to be moderated first).</li>
                                         }
-                                    }
-                                    <div class="collapse @if (anyPackageRole && Model.Status != PackageStatusType.Approved) {<text>show</text>} " id="add-comment">
+                                        @if (!hasPreviousExistingVersions)
+                                        {
+                                            <li>NOTE! This is a brand new package with no previous existing versions (prereleases do not count): check the name of the package. Does it meet the guidelines? This makes a package immediately rejectable as new package id will be submitted as a different package.</li>
+                                        }
+                                        <li>Check tags</li>
+                                        <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
+                                        <li>Be Nice! :)</li>
+                                    </ul>
+                                }
+                                else
+                                {
+                                    <hr />
+                                    <h3 class="mt-3">Instructions for Comments:</h3>
+                                    <ul>
+                                        <li>You can respond to review comments here.</li>
+                                        <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
+                                        @if (Model.Status == PackageStatusType.Submitted)
+                                        {
+                                            <li>You are also able to self-reject packages that may be out of date or incorrect (if the verifier fails the install). See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">self-reject</a> for more information.</li>
+                                        }
+                                    </ul>
+                                }
+                                @using (Html.BeginForm())
+                                {
+                                    <fieldset class="form">
+                                        <div class="form-field d-label-none">
+                                            @Html.LabelFor(m => m.NewReviewComments)
+                                            @Html.TextAreaFor(m => m.NewReviewComments, new { @cols = 80, @rows = 5, @placeholder = "Add to Review Comments" })
+                                            @Html.ValidationMessageFor(m => m.NewReviewComments)
+                                            <span class="field-hint-message"></span>
+                                        </div>
+                                        <div class="form-field mt-2 font-weight-bold">
+                                            @Html.LabelFor(m => m.Status)
+                                            @if (moderator)
+                                            {
+                                                @Html.DropDownListFor(m => m.Status, statuses)
+                                            }
+                                            else
+                                            {
+                                                @Html.DisplayTextFor(m => m.Status)
+                                            }
+                                            @Html.ValidationMessageFor(m => m.Status)
+                                            <span class="field-hint-message"></span>
+                                        </div>
+                                        @if (moderator || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
+                                        {
+                                            <div class="form-field">
+                                                <input id="RerunTests" name="RerunTests" type="checkbox" value="true" />
+                                                <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun verification tests?</label>
+                                            </div>
+                                        }
+                                        @if (moderator && Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
+                                        {
+                                            <div class="form-field">
+                                                <input id="RerunValidation" name="RerunValidation" type="checkbox" value="true" />
+                                                <label for="RerunValidation" class="for-checkbox" title="Rerun package validation tests.">Rerun validation tests?</label>
+                                            </div>
+                                            <div class="form-field">
+                                                <input id="OverrideValidation" name="OverrideValidation" type="checkbox" value="true" />
+                                                <label for="OverrideValidation" class="for-checkbox" title="Override package validation failures and run tests.">Override validation errors?</label>
+                                            </div>
+                                        }
+                                        @if (moderator)
+                                        {
+                                            <div class="form-field">
+                                                <input id="RerunVirusScanner" name="RerunVirusScanner" type="checkbox" value="true" />
+                                                <label for="RerunVirusScanner" class="for-checkbox" title="Rerun virus scanner to get latest reports.">Rerun virus scanner?</label>
+                                            </div>
+                                        }
                                         @if (moderationRole)
                                         {
-                                            <hr />
-                                            <h3 class="mt-3">Instructions for Review:</h3>
-                                            <ul>
-                                                <li>Reviewers/Moderators must follow review process at <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "moderation" })#reviewer--moderator-process">moderation</a>.
-                                                <li>**Please do not reject a package until the end of the conversation.**</li>
-                                                <li>Check over the powershell scripts - anything look unsafe? Download urls should be official distro</li>
-                                                @if (Model.Status == PackageStatusType.Approved || Model.Status == PackageStatusType.Exempted)
-                                                {
-                                                    <li>Moderators: Be very careful about moving a package from approved/exempt into submitted status. A package may be repushed when in this status (no matter how many downloads).</li>
-                                                }
-                                                @if (Model.Dependencies.DependencySets.Any())
-                                                {
-                                                    <li>Check dependencies, make sure they are listed on the site (approved if they needed to be moderated first).</li>
-                                                }
-                                                @if (!hasPreviousExistingVersions)
-                                                {
-                                                    <li>NOTE! This is a brand new package with no previous existing versions (prereleases do not count): check the name of the package. Does it meet the guidelines? This makes a package immediately rejectable as new package id will be submitted as a different package.</li>
-                                                }
-                                                <li>Check tags</li>
-                                                <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
-                                                <li>Be Nice! :)</li>
-                                            </ul>
+                                            <div class="form-field">
+                                                <input id="SendEmail" name="SendEmail" type="checkbox" checked="checked" value="true" />
+                                                <label for="SendEmail" class="for-checkbox" title="Send an email to the maintainer? They won't receive notice of your action otherwise. With normal review operations, it is normal to leave this checked.">Send Maintainer email?</label>
+                                            </div>
+                                            <div class="form-field">
+                                                <input id="ChangeSubmittedStatus" name="ChangeSubmittedStatus" type="checkbox" checked="checked" value="true" />
+                                                <label for="ChangeSubmittedStatus" class="for-checkbox" title="If just rerunning tests or leaving a non-flagging comment (e.g. not requiring changes by the maintainer(s)), uncheck this box.">If Submitted status, require maintainer to make changes?</label>
+                                            </div>
                                         }
-                                        else
+                                        else if (maintainer && Model.Status == PackageStatusType.Submitted && (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing))
                                         {
-                                            <hr />
-                                            <h3 class="mt-3">Instructions for Comments:</h3>
-                                            <ul>
-                                                <li>You can respond to review comments here.</li>
-                                                <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
-                                                @if (Model.Status == PackageStatusType.Submitted)
-                                                {
-                                                    <li>You are also able to self-reject packages that may be out of date or incorrect (if the verifier fails the install). See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">self-reject</a> for more information.</li>
-                                                }
-                                            </ul>
+                                            <div class="form-field">
+                                                <input id="MaintainerReject" name="MaintainerReject" type="checkbox" value="true" onclick="if (this.checked) { return confirm('Are you sure? It is not normal to reject a package.'); }" />
+                                                <label for="MaintainerReject" class="for-checkbox" title="If the download link is always the same and you have some older versions under review, the older versions can be rejected without issue. Under normal circumstances this should not be used.">Reject Package? Not for <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">normal scenarios or obsoletion</a>.</label>
+                                            </div>
                                         }
-                                        @using (Html.BeginForm())
+                                        @Html.ValidationSummary(true)
+                                        @if (moderationRole)
                                         {
-                                            <fieldset class="form">
-                                                <div class="form-field d-label-none">
-                                                    @Html.LabelFor(m => m.NewReviewComments)
-                                                    @Html.TextAreaFor(m => m.NewReviewComments, new { @cols = 80, @rows = 5, @placeholder = "Add to Review Comments" })
-                                                    @Html.ValidationMessageFor(m => m.NewReviewComments)
-                                                    <span class="field-hint-message"></span>
-                                                </div>
-                                                <div class="form-field mt-2 font-weight-bold">
-                                                    @Html.LabelFor(m => m.Status)
+                                            <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-trusted" aria-expanded="false" aria-controls="test-trusted">Show Trusted Section</button>
+                                            <div class="collapse form-field" id="test-trusted">
+                                                <ul class="mb-0 mt-3">
+                                                    <li>Trusted package ids are packages where we have built trust in the package maintainer(s).</li>
+                                                    <li>This usually happens after we have seen several iterations of a package without issues.</li>
+                                                    <li>All package *versions* submitted from now on will automatically be approved.</li>
+                                                    <li>This also happens when maintainer is also the author of the software.</li>
                                                     @if (moderator)
                                                     {
-                                                        @Html.DropDownListFor(m => m.Status, statuses)
+                                                        <li>Use with care.</li>
+                                                        <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
                                                     }
-                                                    else
-                                                    {
-                                                        @Html.DisplayTextFor(m => m.Status)
-                                                    }
-                                                    @Html.ValidationMessageFor(m => m.Status)
-                                                    <span class="field-hint-message"></span>
-                                                </div>
-                                                @if (moderator || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                                {
-                                                    <div class="form-field">
-                                                        <input id="RerunTests" name="RerunTests" type="checkbox" value="true" />
-                                                        <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun verification tests?</label>
-                                                    </div>
-                                                }
-                                                @if (moderator && Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                                {
-                                                    <div class="form-field">
-                                                        <input id="RerunValidation" name="RerunValidation" type="checkbox" value="true" />
-                                                        <label for="RerunValidation" class="for-checkbox" title="Rerun package validation tests.">Rerun validation tests?</label>
-                                                    </div>
-                                                    <div class="form-field">
-                                                        <input id="OverrideValidation" name="OverrideValidation" type="checkbox" value="true" />
-                                                        <label for="OverrideValidation" class="for-checkbox" title="Override package validation failures and run tests.">Override validation errors?</label>
-                                                    </div>
-                                                }
+                                                </ul>
                                                 @if (moderator)
                                                 {
-                                                    <div class="form-field">
-                                                        <input id="RerunVirusScanner" name="RerunVirusScanner" type="checkbox" value="true" />
-                                                        <label for="RerunVirusScanner" class="for-checkbox" title="Rerun virus scanner to get latest reports.">Rerun virus scanner?</label>
-                                                    </div>
+                                                    @Html.EditorFor(m => m.IsTrusted)
+                                                    <label for="IsTrusted" class="mt-2 mb-0 pb-2">Trust this package id?</label>
                                                 }
-                                                @if (moderationRole)
+                                                else
                                                 {
-                                                    <div class="form-field">
-                                                        <input id="SendEmail" name="SendEmail" type="checkbox" checked="checked" value="true" />
-                                                        <label for="SendEmail" class="for-checkbox" title="Send an email to the maintainer? They won't receive notice of your action otherwise. With normal review operations, it is normal to leave this checked.">Send Maintainer email?</label>
-                                                    </div>
-                                                    <div class="form-field">
-                                                        <input id="ChangeSubmittedStatus" name="ChangeSubmittedStatus" type="checkbox" checked="checked" value="true" />
-                                                        <label for="ChangeSubmittedStatus" class="for-checkbox" title="If just rerunning tests or leaving a non-flagging comment (e.g. not requiring changes by the maintainer(s)), uncheck this box.">If Submitted status, require maintainer to make changes?</label>
-                                                    </div>
+                                                    var trustedText = @Model.IsTrusted ? "is trusted" : "follows normal workflow";
+                                                    <p class="mt-2 mb-0 pb-2">This package @trustedText.</p>
                                                 }
-                                                else if (maintainer && Model.Status == PackageStatusType.Submitted && (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing))
+                                            </div>
+                                            <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-exemptions" aria-expanded="false" aria-controls="test-exemptions">Show Testing Exemption Section</button>
+                                            <div class="collapse form-field" id="test-exemptions">
+                                                <ul class="mb-0 mt-3">
+                                                    <li>Exempting a package id from testing requires a reason.</li>
+                                                    @if (moderator)
+                                                    {
+                                                        <li>Use with care.</li>
+                                                        <li>Typically this is done when a package is installing drivers the testing computer does not have</li>
+                                                        <li>This is NOT done just because a maintainer doesn't know how to make a program silent with Auto Hot Key.</li>
+                                                        <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
+                                                    }
+                                                </ul>
+                                                @if (moderator)
                                                 {
-                                                    <div class="form-field">
-                                                        <input id="MaintainerReject" name="MaintainerReject" type="checkbox" value="true" onclick="if (this.checked) { return confirm('Are you sure? It is not normal to reject a package.'); }" />
-                                                        <label for="MaintainerReject" class="for-checkbox" title="If the download link is always the same and you have some older versions under review, the older versions can be rejected without issue. Under normal circumstances this should not be used.">Reject Package? Not for <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">normal scenarios or obsoletion</a>.</label>
+                                                    @Html.EditorFor(m => m.IsExemptedFromVerification)
+                                                    <label for="IsExemptedFromVerification" class="mt-2 mb-3">Exempt the package from verification testing?</label>
+                                                    <div class="form-field d-label-none pb-2">
+                                                        @Html.LabelFor(m => m.ExemptedFromVerificationReason)
+                                                        @Html.TextAreaFor(m => m.ExemptedFromVerificationReason, new { @cols = 80, @rows = 5, @placeholder = "Exempted Reason" })
+                                                        @Html.ValidationMessageFor(m => m.ExemptedFromVerificationReason)
                                                     </div>
                                                 }
-                                                @Html.ValidationSummary(true)
-                                                @if (moderationRole)
+                                                else
                                                 {
-                                                    <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-trusted" aria-expanded="false" aria-controls="test-trusted">Show Trusted Section</button>
-                                                    <div class="collapse form-field" id="test-trusted">
-                                                        <ul class="mb-0 mt-3">
-                                                            <li>Trusted package ids are packages where we have built trust in the package maintainer(s).</li>
-                                                            <li>This usually happens after we have seen several iterations of a package without issues.</li>
-                                                            <li>All package *versions* submitted from now on will automatically be approved.</li>
-                                                            <li>This also happens when maintainer is also the author of the software.</li>
-                                                            @if (moderator)
-                                                            {
-                                                                <li>Use with care.</li>
-                                                                <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
-                                                            }
-                                                        </ul>
-                                                        @if (moderator)
-                                                        {
-                                                            @Html.EditorFor(m => m.IsTrusted)
-                                                            <label for="IsTrusted" class="mt-2 mb-0 pb-2">Trust this package id?</label>
-                                                        }
-                                                        else
-                                                        {
-                                                            var trustedText = @Model.IsTrusted ? "is trusted" : "follows normal workflow";
-                                                            <p class="mt-2 mb-0 pb-2">This package @trustedText.</p>
-                                                        }
-                                                    </div>
-                                                    <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-exemptions" aria-expanded="false" aria-controls="test-exemptions">Show Testing Exemption Section</button>
-                                                    <div class="collapse form-field" id="test-exemptions">
-                                                        <ul class="mb-0 mt-3">
-                                                            <li>Exempting a package id from testing requires a reason.</li>
-                                                            @if (moderator)
-                                                            {
-                                                                <li>Use with care.</li>
-                                                                <li>Typically this is done when a package is installing drivers the testing computer does not have</li>
-                                                                <li>This is NOT done just because a maintainer doesn't know how to make a program silent with Auto Hot Key.</li>
-                                                                <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
-                                                            }
-                                                        </ul>
-                                                        @if (moderator)
-                                                        {
-                                                            @Html.EditorFor(m => m.IsExemptedFromVerification)
-                                                            <label for="IsExemptedFromVerification" class="mt-2 mb-3">Exempt the package from verification testing?</label>
-                                                            <div class="form-field d-label-none pb-2">
-                                                                @Html.LabelFor(m => m.ExemptedFromVerificationReason)
-                                                                @Html.TextAreaFor(m => m.ExemptedFromVerificationReason, new { @cols = 80, @rows = 5, @placeholder = "Exempted Reason" })
-                                                                @Html.ValidationMessageFor(m => m.ExemptedFromVerificationReason)
-                                                            </div>
-                                                        }
-                                                        else
-                                                        {
-                                                            var testInformation = @Model.IsExemptedFromVerification ? "skips automatic verification (testing)" : "follows normal workflow";
-                                                            <p class="mt-2 mb-0 pb-2">This package @testInformation.</p>
-                                                        }
-                                                    </div>
+                                                    var testInformation = @Model.IsExemptedFromVerification ? "skips automatic verification (testing)" : "follows normal workflow";
+                                                    <p class="mt-2 mb-0 pb-2">This package @testInformation.</p>
                                                 }
-                                                <button class="btn btn-success d-block mt-2" type="submit" value="Save" title="Save Changes"><i class="fas fa-save" alt="Save"></i> Save</button>
-                                            </fieldset>
+                                            </div>
                                         }
-                                    </div>
+                                        <button class="btn btn-success d-block mt-2" type="submit" value="Save" title="Save Changes"><i class="fas fa-save" alt="Save"></i> Save</button>
+                                    </fieldset>
                                 }
                             </div>
                         }
-                    }
-                </div>
-            </div>
-            @*  Description  *@
-            <div class="row mb-4">
-                <div id="description" class="col-12">
-                    <a class="h2 collapse show" data-toggle="collapse" href="#package-description" role="button" aria-expanded="true" aria-controls="description" title="Nuspec reference: description">Description</a>
-                    <div class="collapse show" id="package-description">
-                        <hr />
-                        @Html.Raw(markdownGenerator.Transform(Model.Description.clean_html()))
                     </div>
+                }
+            }
+            @*  Description  *@
+            <div class="mb-4">
+                <a class="h2 collapse show" data-toggle="collapse" href="#description" role="button" aria-expanded="true" aria-controls="description" title="Nuspec reference: description">Description</a>
+                <div class="collapse show" id="description">
+                    <hr />
+                    @Html.Raw(markdownGenerator.Transform(Model.Description.clean_html()))
                 </div>
             </div>
             @*  Files  *@
-            <div class="row mb-4">
-                <div id="files" class="col-12">
-                    <a class="h2 @if (expandForModeration && moderator) {<text> collapse show</text>} else {<text>collapsed</text>}" data-toggle="collapse" href="#package-files" role="button" aria-expanded="false" aria-controls="files" title="Nuspec reference: files, optional - will default to all files next to nuspec">Files</a>
-                    <div class="collapse @if (expandForModeration && moderator) {<text> show moderation-view</text>}" id="package-files">
-                        <hr />
-                        @if (expandForModeration)
-                        {
-                            <button type="button" class="btn btn-danger mb-2"><i class="fas fa-minus-circle" alt="Collapse Files"></i> Collapse Files</button>
-                            var nuspecId = @Model.Id.Replace(".", "-") + "-nuspec";
-                            <div class="collapse-2 mb-1">
-                                <button type="button" class="btn btn-sm btn-secondary mr-2">Hide</button>
-                                @Model.Id<span>.nuspec</span>
-                                <div class="collapse-2-content d-block">
+            <div class="mb-4">
+                <a class="h2 @if (expandForModeration && moderator) {<text> collapse show</text>} else {<text>collapsed</text>}" data-toggle="collapse" href="#files" role="button" aria-expanded="false" aria-controls="files" title="Nuspec reference: files, optional - will default to all files next to nuspec">Files</a>
+                <div class="collapse @if (expandForModeration && moderator) {<text> show moderation-view</text>}" id="files">
+                    <hr />
+                    @if (expandForModeration)
+                    {
+                        <button type="button" class="btn btn-danger mb-2"><i class="fas fa-minus-circle" alt="Collapse Files"></i> Collapse Files</button>
+                        var nuspecId = @Model.Id.Replace(".", "-") + "-nuspec";
+                        <div class="collapse-2 mb-1">
+                            <button type="button" class="btn btn-sm btn-secondary mr-2">Hide</button>
+                            @Model.Id<span>.nuspec</span>
+                            <div class="collapse-2-content d-block">
 <pre><code>&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;!-- This is not exact, it's only based on what is stored about the package --&gt;
 &lt;!-- description and releaseNotes left out for brevity --&gt;
@@ -1286,188 +1269,175 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
 }
 &lt;/metadata&gt;
 &lt;/package&gt;</code></pre>
+                            </div>
+                        </div>
+                    }
+                    @if (Model.Files.Any())
+                    {
+                        var random = new Random();
+                        foreach (var file in Model.Files)
+                        {
+                            <div class="collapse-2 mb-1">
+                                @if (!string.IsNullOrWhiteSpace(file.FileContent))
+                                {
+                                    var fileDivId = "div-" + Path.GetFileName(file.FilePath).Replace(".", "-").Replace(" ", string.Empty) + "-" + random.Next();
+                                    if (expandForModeration)
+                                    {
+                                        <button type="button" class="btn btn-sm btn-secondary mr-2 ">Hide</button>
+                                    }
+                                    else
+                                    {
+                                        <button type="button" class="btn btn-sm btn-secondary mr-2">Show</button>
+                                    }
+                                }
+                                @file.FilePath
+                                <div class="collapse-2-content d-none">
+                                    <pre class=""><code class="">@file.FileContent</code></pre>
                                 </div>
                             </div>
                         }
-                        @if (Model.Files.Any())
-                        {
-                            var random = new Random();
-                            foreach (var file in Model.Files)
-                            {
-                                <div class="collapse-2 mb-1">
-                                    @if (!string.IsNullOrWhiteSpace(file.FileContent))
-                                    {
-                                        var fileDivId = "div-" + Path.GetFileName(file.FilePath).Replace(".", "-").Replace(" ", string.Empty) + "-" + random.Next();
-                                        if (expandForModeration)
-                                        {
-                                            <button type="button" class="btn btn-sm btn-secondary mr-2 ">Hide</button>
-                                        }
-                                        else
-                                        {
-                                            <button type="button" class="btn btn-sm btn-secondary mr-2">Show</button>
-                                        }
-                                    }
-                                    @file.FilePath
-                                    <div class="collapse-2-content d-none">
-                                        <pre class=""><code class="">@file.FileContent</code></pre>
-                                    </div>
-                                </div>
-                            }
-                        }
-                    </div>
+                    }
                 </div>
             </div>
             @*  Virus Scan  *@
-            <div class="row mb-4">
-                <div id="virus" class="col-12">
-                    <a class="h2 @if (expandForModeration && moderator) {<text> collapse show</text>} else {<text>collapsed</text>}" data-toggle="collapse" href="#package-virus" role="button" aria-expanded="false" aria-controls="virus" title="Virus Scan Results">Virus Scan Results</a>
-                    <div class="collapse @if (expandForModeration && moderator) {<text> show </text>}" id="package-virus">
-                        @if (Model.ScanResults.AnySafe())
-                        {
-                            <hr />
-                            <ul class="list-unstyled">
-                                @foreach (var fileScan in Model.ScanResults.OrEmptyListIfNull())
-                                {
-                                    <li>
-                                        <a title="full sha256: @fileScan.Sha256Checksum" href="@fileScan.ScanDetailsUrl">@fileScan.FileName (@fileScan.Sha256Checksum.Substring(0, 12))</a>
-                                        @if (User != null && HttpContext.Current.User.Identity.IsAuthenticated)
-                                        {
-                                            <text>-</text> @fileScan.Positives<text>/</text>@fileScan.TotalScans
-                                        }
-                                        else
-                                        {
-                                            <text>- ## / </text> @fileScan.TotalScans <text> - Log in or click on link to see number of positives</text>
-                                        }
-                                    </li>
-                                }
-                            </ul>
-                            <div class="callout callout-warning">
-                                <p>In cases where actual malware is found, the packages are subject to removal. Software sometimes has false positives. Moderators do not necessarily validate the safety of the underlying software, only that a package retrieves software from the official distribution point and/or validate embedded software against official distribution point (where distribution rights allow redistribution).</p>
-                                <p>Chocolatey Pro provides <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-virus-check" })">runtime protection</a> from possible malware.</p>
-                            </div>
-                        }
-                        else
-                        {
-                            <div class="callout callout-warning mt-3">
-                                <p>No results available for this package. We are building up results for older packages over time so expect to see results. If this is a new package, it should have results within a day or two.</p>
-                            </div>
-                        }
-                    </div>
+            <div class="mb-4">
+                <a class="h2 @if (expandForModeration && moderator) {<text> collapse show</text>} else {<text>collapsed</text>}" data-toggle="collapse" href="#virus" role="button" aria-expanded="false" aria-controls="virus" title="Virus Scan Results">Virus Scan Results</a>
+                <div class="collapse @if (expandForModeration && moderator) {<text> show </text>}" id="virus">
+                    @if (Model.ScanResults.AnySafe())
+                    {
+                        <hr />
+                        <ul class="list-unstyled">
+                            @foreach (var fileScan in Model.ScanResults.OrEmptyListIfNull())
+                            {
+                                <li>
+                                    <a title="full sha256: @fileScan.Sha256Checksum" href="@fileScan.ScanDetailsUrl">@fileScan.FileName (@fileScan.Sha256Checksum.Substring(0, 12))</a>
+                                    @if (User != null && HttpContext.Current.User.Identity.IsAuthenticated)
+                                    {
+                                        <text>-</text> @fileScan.Positives<text>/</text>@fileScan.TotalScans
+                                    }
+                                    else
+                                    {
+                                        <text>- ## / </text> @fileScan.TotalScans <text> - Log in or click on link to see number of positives</text>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                        <div class="callout callout-warning">
+                            <p>In cases where actual malware is found, the packages are subject to removal. Software sometimes has false positives. Moderators do not necessarily validate the safety of the underlying software, only that a package retrieves software from the official distribution point and/or validate embedded software against official distribution point (where distribution rights allow redistribution).</p>
+                            <p>Chocolatey Pro provides <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "features-virus-check" })">runtime protection</a> from possible malware.</p>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="callout callout-warning mt-3">
+                            <p>No results available for this package. We are building up results for older packages over time so expect to see results. If this is a new package, it should have results within a day or two.</p>
+                        </div>
+                    }
                 </div>
             </div>
             @*  Version History  *@
-            <div class="row mb-4">
-                <div id="versionhistory" class="col-12">
-                    <a class="h2 @if(expandForModeration && moderator){<text> collapse show</text>}else{<text>collapsed</text>}" data-toggle="collapse" href="#package-versionhistory" role="button" aria-expanded="false" aria-controls="versionhistory" title="Version History">Version History</a>
-                    <div class="collapse @if(expandForModeration && moderator){<text> show</text>}" id="package-versionhistory">
-                        <div class="table-responsive-sm">
-                            <table class="table table-hover mt-3">
-                                <thead>
-                                    <tr>
-                                        <th scope="col">Version</th>
-                                        <th scope="col">Downloads</th>
-                                        <th scope="col">Last Updated</th>
-                                        @if (Model.IsOwner(User))
-                                        {
-                                            <th scope="col @(moderationRole ? "" : "last")">Listed</th>
-                                        }
-                                        <th scope="col" @(moderationRole ? "" : "last")>Status</th>
-                                        @if (moderationRole)
-                                        {
-                                            <th scope="col">Notes</th>
-                                        }
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach (var packageVersion in Model.PackageVersions.Take(packageVersions < packageVersionsDefaultDisplay ? packageVersions : packageVersionsDefaultDisplay))
+            <div class="mb-4">
+                <a class="h2 @if(expandForModeration && moderator){<text> collapse show</text>}else{<text>collapsed</text>}" data-toggle="collapse" href="#versionhistory" role="button" aria-expanded="false" aria-controls="versionhistory" title="Version History">Version History</a>
+                <div class="collapse @if(expandForModeration && moderator){<text> show</text>}" id="versionhistory">
+                    <div class="table-responsive-sm">
+                        <table class="table table-hover mt-3">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Version</th>
+                                    <th scope="col">Downloads</th>
+                                    <th scope="col">Last Updated</th>
+                                    @if (Model.IsOwner(User))
                                     {
-                                        var packageVersionList = new ListPackageVersionViewModel(packageVersion, Model, moderationRole, markdownGenerator, displayVersion: true);
+                                        <th scope="col @(moderationRole ? "" : "last")">Listed</th>
+                                    }
+                                    <th scope="col" @(moderationRole ? "" : "last")>Status</th>
+                                    @if (moderationRole)
+                                    {
+                                        <th scope="col">Notes</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var packageVersion in Model.PackageVersions.Take(packageVersions < packageVersionsDefaultDisplay ? packageVersions : packageVersionsDefaultDisplay))
+                                {
+                                    var packageVersionList = new ListPackageVersionViewModel(packageVersion, Model, moderationRole, markdownGenerator, displayVersion: true);
+                                    @Html.Partial("_ListVersion", packageVersionList)
+                                }
+                                @if (packageVersions > packageVersionsDefaultDisplay)
+                                {
+                                    foreach (var packageVersion in Model.PackageVersions.Skip(packageVersionsDefaultDisplay))
+                                    {
+                                        var packageVersionList = new ListPackageVersionViewModel(packageVersion, Model, moderationRole, markdownGenerator, displayVersion: false);
                                         @Html.Partial("_ListVersion", packageVersionList)
                                     }
-                                    @if (packageVersions > packageVersionsDefaultDisplay)
-                                    {
-                                        foreach (var packageVersion in Model.PackageVersions.Skip(packageVersionsDefaultDisplay))
-                                        {
-                                            var packageVersionList = new ListPackageVersionViewModel(packageVersion, Model, moderationRole, markdownGenerator, displayVersion: false);
-                                            @Html.Partial("_ListVersion", packageVersionList)
-                                        }
-                                    }
-                                </tbody>
-                            </table>
-                            @if (packageVersions > packageVersionsDefaultDisplay)
-                            {
-                                <button type="button" class="btn btn-sm btn-secondary" onclick="if($(this).is(':contains(&quot;Hide&quot;)')){$('.versionTableRowMore').hide();}else{$('.versionTableRowMore').show();}">Show Additional Versions</button>
-                            }
-                        </div>
+                                }
+                            </tbody>
+                        </table>
+                        @if (packageVersions > packageVersionsDefaultDisplay)
+                        {
+                            <button type="button" class="btn btn-sm btn-secondary" onclick="if($(this).is(':contains(&quot;Hide&quot;)')){$('.versionTableRowMore').hide();}else{$('.versionTableRowMore').show();}">Show Additional Versions</button>
+                        }
                     </div>
                 </div>
             </div>
             @*  Copyright  *@
             @if (!String.IsNullOrEmpty(Model.Copyright))
             {
-                <div class="row mb-4">
-                    <div id="copyright" class="col-12">
-                        <a class="h2 collapsed" data-toggle="collapse" href="#package-copyright" role="button" aria-expanded="false" aria-controls="copyright" title="Nuspec reference: copyright">Copyright</a>
-                        <div class="collapse" id="package-copyright">
-                            <hr />
-                            <p mb-0>@Model.Copyright</p>
-                        </div>
+                <div class="mb-4">
+                    <a class="h2 collapsed" data-toggle="collapse" href="#copyright" role="button" aria-expanded="false" aria-controls="copyright" title="Nuspec reference: copyright">Copyright</a>
+                    <div class="collapse" id="copyright">
+                        <hr />
+                        <p class="mb-0">@Model.Copyright</p>
                     </div>
                 </div>
             }
             @*  Release Notes  *@
             @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
             {
-                <div class="row mb-4">
-                    <div id="releasenotes" class="col-12">
-                        <a class="h2 collapsed" data-toggle="collapse" href="#package-releasenotes" role="button" aria-expanded="false" aria-controls="releasenotes" title="Nuspec reference: releaseNotes">Release Notes</a>
-                        <div class="collapse" id="package-releasenotes">
-                            <hr />
-                            @Html.Raw(markdownGenerator.Transform(Model.ReleaseNotes.clean_html()))
-                        </div>
+                <div class="mb-4">
+                    <a class="h2 collapsed" data-toggle="collapse" href="#releasenotes" role="button" aria-expanded="false" aria-controls="releasenotes" title="Nuspec reference: releaseNotes">Release Notes</a>
+                    <div class="collapse" id="releasenotes">
+                        <hr />
+                        @Html.Raw(markdownGenerator.Transform(Model.ReleaseNotes.clean_html()))
                     </div>
                 </div>
             }
             @*  Dependencies  *@
-            <div class="row mb-4">
-                <div id="dependencies" class="col-12">
-                    <a class="h2 @if(expandForModeration && moderator){<text> collapse show</text>}else{<text>collapsed</text>}" data-toggle="collapse" href="#package-dependencies" role="button" aria-expanded="false" aria-controls="dependencies" title="Nuspec reference: dependencies">Dependencies</a>
-                    <div class="collapse @if(expandForModeration && moderator){<text> show</text>}" id="package-dependencies">
-                        <hr />
-                        @Html.Partial("_PackageDependencies", Model.Dependencies)
-                    </div>
+            <div class="mb-4">
+                <a class="h2 @if(expandForModeration && moderator){<text> collapse show</text>}else{<text>collapsed</text>}" data-toggle="collapse" href="#dependencies" role="button" aria-expanded="false" aria-controls="dependencies" title="Nuspec reference: dependencies">Dependencies</a>
+                <div class="collapse @if(expandForModeration && moderator){<text> show</text>}" id="dependencies">
+                    <hr />
+                    @Html.Partial("_PackageDependencies", Model.Dependencies)
                 </div>
             </div>
             @*  Discussion  *@
-            <div class="row">
-                <div id="discussion" class="col-12">
-                    <a class="h2 collapse show" data-toggle="collapse" href="#package-discussion" role="button" aria-expanded="true" aria-controls="discussion" title=">Discussion for the @Model.Title Package">Discussion for the @Model.Title Package</a>
-                    <div class="collapse show" id="package-discussion">
-                        <hr />
-                        <h3>Ground Rules:</h3>
-                        <ul>
-                            <li>This discussion is only about @Model.Title and the @Model.Title package. If you have feedback for Chocolatey, please contact the <a href="http://groups.google.com/group/chocolatey">Google Group</a>.</li>
-                            <li>This discussion will carry over multiple versions. If you have a comment about a particular version, please note that in your comments.</li>
-                            <li>
-                                The maintainers of this Chocolatey Package will be notified about new comments that are posted to this Disqus thread, however, it is NOT a guarantee that you
-                                will get a response. If you do not hear back from the maintainers after posting a message below, please follow up by using the link
-                                on the left side of this page or follow this link to <a href="@Url.Action(MVC.Packages.ContactOwners(Model.Id))">contact maintainers</a>.
-                                If you still hear nothing back, please follow the <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "package-triage-process" })">package triage process</a>.
-                            </li>
-                            <li>Tell us what you love about the package or @Model.Title, or tell us what needs improvement.</li>
-                            <li>Share your experiences with the package, or extra configuration or gotchas that you've found.</li>
-                            <li>If you use a url, the comment will be flagged for moderation until you've been whitelisted. Disqus moderated comments are approved on a weekly schedule if not sooner. It could take between 1-5 days for your comment to show up.</li>
-                        </ul>
-                        @{
-                            var disqusUrl = "http://" + Request.Url.Host + @Url.Package(Model.Id);
-                            var disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
-                            bool forceSsl = Convert.ToBoolean(System.Configuration.ConfigurationManager.AppSettings["ForceSSL"]);
-                            var commentPostUrl = (forceSsl ? "https" : Request.Url.Scheme) + "://" + Request.Url.Authority + @Url.Package(Model.Id) + "/notify-comment";
-                        }
-                        <a name="disqus"></a>
-                        <div id="disqus_thread"></div>
-                        <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-                    </div>
+            <div>
+                <a class="h2 collapse show" data-toggle="collapse" href="#discussion" role="button" aria-expanded="true" aria-controls="discussion" title=">Discussion for the @Model.Title Package">Discussion for the @Model.Title Package</a>
+                <div class="collapse show" id="discussion">
+                    <hr />
+                    <h3>Ground Rules:</h3>
+                    <ul>
+                        <li>This discussion is only about @Model.Title and the @Model.Title package. If you have feedback for Chocolatey, please contact the <a href="http://groups.google.com/group/chocolatey">Google Group</a>.</li>
+                        <li>This discussion will carry over multiple versions. If you have a comment about a particular version, please note that in your comments.</li>
+                        <li>
+                            The maintainers of this Chocolatey Package will be notified about new comments that are posted to this Disqus thread, however, it is NOT a guarantee that you
+                            will get a response. If you do not hear back from the maintainers after posting a message below, please follow up by using the link
+                            on the left side of this page or follow this link to <a href="@Url.Action(MVC.Packages.ContactOwners(Model.Id))">contact maintainers</a>.
+                            If you still hear nothing back, please follow the <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "package-triage-process" })">package triage process</a>.
+                        </li>
+                        <li>Tell us what you love about the package or @Model.Title, or tell us what needs improvement.</li>
+                        <li>Share your experiences with the package, or extra configuration or gotchas that you've found.</li>
+                        <li>If you use a url, the comment will be flagged for moderation until you've been whitelisted. Disqus moderated comments are approved on a weekly schedule if not sooner. It could take between 1-5 days for your comment to show up.</li>
+                    </ul>
+                    @{
+                        var disqusUrl = "http://" + Request.Url.Host + @Url.Package(Model.Id);
+                        var disqusShortname = System.Configuration.ConfigurationManager.AppSettings["DisqusShortname"];
+                        bool forceSsl = Convert.ToBoolean(System.Configuration.ConfigurationManager.AppSettings["ForceSSL"]);
+                        var commentPostUrl = (forceSsl ? "https" : Request.Url.Scheme) + "://" + Request.Url.Authority + @Url.Package(Model.Id) + "/notify-comment";
+                    }
+                    <a name="disqus"></a>
+                    <div id="disqus_thread"></div>
+                    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
                 </div>
             </div>
         </div>

--- a/chocolatey/Website/Views/Pages/Install.cshtml
+++ b/chocolatey/Website/Views/Pages/Install.cshtml
@@ -14,7 +14,7 @@
 <section class="py-3 py-md-5 container">
     <h1 class="text-center mb-4">Installing Chocolatey</h1>
     <div class="bg-primary shadow p-2">
-        <a class="h3 collapse show" data-toggle="collapse" href="#install-step1" role="button" aria-expanded="true" aria-controls="install-step1" title="Install Step 1"><strong>Step 1: Subscribe to the Chocolatey Newsletter</strong></a>
+        <a class="h3 font-weight-bold collapse show" data-toggle="collapse" href="#install-step1" role="button" aria-expanded="true" aria-controls="install-step1" title="Install Step 1">Step 1: Subscribe to the Chocolatey Newsletter</a>
     </div>
     <div class="collapse show bg-white shadow" id="install-step1">
         <div class="p-3">
@@ -37,7 +37,7 @@
         </div>
     </div>
     <div class="bg-primary shadow p-2 mt-4">
-        <a class="h3 collapse show" data-toggle="collapse" href="#install-step2" role="button" aria-expanded="true" aria-controls="install-step2" title="Install Step 2"><strong>Step 2: Choose Your Installation Method</strong></a>
+        <a class="h3 font-weight-bold collapse show" data-toggle="collapse" href="#install-step2" role="button" aria-expanded="true" aria-controls="install-step2" title="Install Step 2">Step 2: Choose Your Installation Method</a>
     </div>
     <div class="collapse show bg-white shadow" id="install-step2">
         <div class="p-3">

--- a/chocolatey/Website/Views/Pages/Pricing.cshtml
+++ b/chocolatey/Website/Views/Pages/Pricing.cshtml
@@ -5,7 +5,6 @@
     Bundles.Reference("Scripts");
     Bundles.Reference("Scripts/CookiesNotice");
 }
-
 <section id="editions" class="py-3 py-lg-5">
     <div class="container">
         <div class="row text-center pb-4">
@@ -104,169 +103,167 @@
 </section>
 <section class="pb-3 pb-lg-5 bg-white" id="pricing-faq">
     <ul class="bg-white list-unstyled list-inline sticky-nav sticky-top py-3 text-center border-bottom d-none d-md-block">
-        <li class="list-inline-item px-3"><a class="active" href="#Pricing">Pricing</a></li>
-        <li class="list-inline-item px-3"><a href="#Licensing">Licensing</a></li>
-        <li class="list-inline-item px-3"><a href="#Purchasing">Purchasing</a></li>
-        <li class="list-inline-item px-3"><a href="#Renewing">Renewing</a></li>
-        <li class="list-inline-item px-3"><a href="#Support">Support</a></li>
+        <li class="list-inline-item px-3"><a class="collapse-nav collapse show active" data-toggle="collapse" href="#faq-pricing" role="button" aria-expanded="true" aria-controls="faq-pricing">Pricing</a></li>
+        <li class="list-inline-item px-3"><a class="collapse-nav collapsed" data-toggle="collapse" href="#faq-licensing" role="button" aria-expanded="false" aria-controls="faq-licensing">Licensing</a></li>
+        <li class="list-inline-item px-3"><a class="collapse-nav collapsed" data-toggle="collapse" href="#faq-purchasing" role="button" aria-expanded="false" aria-controls="faq-purchasing">Purchasing</a></li>
+        <li class="list-inline-item px-3"><a class="collapse-nav collapsed" data-toggle="collapse" href="#faq-renewing" role="button" aria-expanded="false" aria-controls="faq-renewing">Renewing</a></li>
+        <li class="list-inline-item px-3"><a class="collapse-nav collapsed" data-toggle="collapse" href="#faq-support" role="button" aria-expanded="false" aria-controls="faq-support">Support</a></li>
     </ul>
     <div class="container pt-3 pt-lg-5">
-        <div class="row">
-            @*Pricing*@
-            <div id="Pricing" class="col-12 mb-4">
-                <a class="h2 collapse show" data-toggle="collapse" href="#faq-pricing" role="button" aria-expanded="true" aria-controls="faq-pricing" title="Pricing">Pricing Overview</a>
-                <div class="collapse show" id="faq-pricing">
-                    <hr />
-                    <h3>How is Chocolatey priced?</h3>
-                    <p>Chocolatey is priced on a per node basis. Please see <a href="#Licensing">"What counts as a license?" (below)</a> for more information.</p>
+        @*Pricing*@
+        <div class="mb-4">
+            <a class="h2 collapse show" data-toggle="collapse" href="#faq-pricing" role="button" aria-expanded="true" aria-controls="faq-pricing" title="Pricing">Pricing Overview</a>
+            <div class="collapse show" id="faq-pricing">
+                <hr />
+                <h3>How is Chocolatey priced?</h3>
+                <p>Chocolatey is priced on a per node basis. Please see <a href="#Licensing">"What counts as a license?" (below)</a> for more information.</p>
 
-                    <h3 class="mt-4">What are pricing options?</h3>
-                    <p>For organizations that want to quickly get started, we offer the Chocolatey for Business (C4B) Starter Pack. The Starter Pack allows for up to 35 nodes is priced at $600 per year. This is the minimum pack and ideal for smaller environments, testing, or setting up a proof of concept.</p>
-                    <ul>
-                        <li>Over 35 node pricing starts at $16 per node.</li>
-                        <li>Price breaks begin at 500 nodes with special pricing for larger volumes and multi-year contracts.</li>
-                        <li>We offer special pricing for non-profit organizations and have other opportunities for discounts for all types of organizations. Please see the FAQs just below this.</li>
-                    </ul>
+                <h3 class="mt-4">What are pricing options?</h3>
+                <p>For organizations that want to quickly get started, we offer the Chocolatey for Business (C4B) Starter Pack. The Starter Pack allows for up to 35 nodes is priced at $600 per year. This is the minimum pack and ideal for smaller environments, testing, or setting up a proof of concept.</p>
+                <ul>
+                    <li>Over 35 node pricing starts at $16 per node.</li>
+                    <li>Price breaks begin at 500 nodes with special pricing for larger volumes and multi-year contracts.</li>
+                    <li>We offer special pricing for non-profit organizations and have other opportunities for discounts for all types of organizations. Please see the FAQs just below this.</li>
+                </ul>
 
-                    <h3 class="mt-4">What is included in an annual subscription?</h3>
-                    <p>The annual subscription is an all-inclusive price.</p>
-                    <p>An annual subscription includes:</p>
-                    <ul>
-                        <li>Licensing for all the advanced features in our commercial editions</li>
-                        <li>Upgrades for access to all the features and fixes that come available during your subscription term</li>
-                        <li>Access to our support team, with varying levels based on what you purchase (including an option for 24/7). See <a href="#Support">support below</a> for more information</li>
-                    </ul>
-                    <h3 class="mt-4">Do you also offer perpetual pricing?</h3>
-                    <p>We also offer perpetual pricing on Chocolatey for Business. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
+                <h3 class="mt-4">What is included in an annual subscription?</h3>
+                <p>The annual subscription is an all-inclusive price.</p>
+                <p>An annual subscription includes:</p>
+                <ul>
+                    <li>Licensing for all the advanced features in our commercial editions</li>
+                    <li>Upgrades for access to all the features and fixes that come available during your subscription term</li>
+                    <li>Access to our support team, with varying levels based on what you purchase (including an option for 24/7). See <a href="#Support">support below</a> for more information</li>
+                </ul>
+                <h3 class="mt-4">Do you also offer perpetual pricing?</h3>
+                <p>We also offer perpetual pricing on Chocolatey for Business. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
 
-                    <h3 class="mt-4">Do you offer special pricing?</h3>
-                    <p>For Case study / testimonials we can offer discounts on Chocolatey for Business. Multi-year term and volume purchase contracts also provide options for discounts. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
+                <h3 class="mt-4">Do you offer special pricing?</h3>
+                <p>For Case study / testimonials we can offer discounts on Chocolatey for Business. Multi-year term and volume purchase contracts also provide options for discounts. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
 
-                    <h3 class="mt-4">We are a non-profit/education/government institution. What special pricing do you have available?</h3>
-                    <p>We offer very attractive pricing for education and non-profit organizations. Depending on volume, we have varying levels of special discounts available. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
+                <h3 class="mt-4">We are a non-profit/education/government institution. What special pricing do you have available?</h3>
+                <p>We offer very attractive pricing for education and non-profit organizations. Depending on volume, we have varying levels of special discounts available. <a href="@Url.RouteUrl(RouteName.ContactSales)">Contact us</a> for details.</p>
 
-                    <h3 class="mt-4">Can I add more nodes during my subscription?</h3>
-                    <p>Yes, adding more nodes is easy. Simply let us know the number of nodes you would like to add and we provide a quote. We are also happy to co-term your nodes to current subscription. We would send you an updated licence file.</p>
-                </div>
+                <h3 class="mt-4">Can I add more nodes during my subscription?</h3>
+                <p>Yes, adding more nodes is easy. Simply let us know the number of nodes you would like to add and we provide a quote. We are also happy to co-term your nodes to current subscription. We would send you an updated licence file.</p>
             </div>
-            @*Licensing*@
-            <div id="Licensing" class="col-12 mb-4">
-                <a class="h2 collapsed" data-toggle="collapse" href="#faq-licensing" role="button" aria-expanded="false" aria-controls="faq-licensing" title="Licensing">Licensing</a>
-                <div class="collapse" id="faq-licensing">
-                    <hr />
-                    <h3>What counts as a license?</h3>
-                    <p>Our licensing is per node (machine).</p>
-                    <p>Simply put, every node you deploy Chocolatey packages to, whether physical, virtual, container, on-prem, in the cloud, or in test environments. Every environment, everywhere, all are part of the licensing count.</p>
-                    <p>We aim to keep our licensing simple and transparent.</p>
+        </div>
+        @*Licensing*@
+        <div class="mb-4">
+            <a class="h2 collapsed" data-toggle="collapse" href="#faq-licensing" role="button" aria-expanded="false" aria-controls="faq-licensing" title="Licensing">Licensing</a>
+            <div class="collapse" id="faq-licensing">
+                <hr />
+                <h3>What counts as a license?</h3>
+                <p>Our licensing is per node (machine).</p>
+                <p>Simply put, every node you deploy Chocolatey packages to, whether physical, virtual, container, on-prem, in the cloud, or in test environments. Every environment, everywhere, all are part of the licensing count.</p>
+                <p>We aim to keep our licensing simple and transparent.</p>
 
-                    <h3 class="mt-4">Can I mix open source and commercial Chocolatey?</h3>
-                    <p>
-                        While you technically can, you need to be very careful, physically separating even the repositories you are using. 
-                        If you end up deploying any packages you've built or acquired with licensed features, those open source nodes will also count as licensed nodes for licensing purposes.
-                    </p>
+                <h3 class="mt-4">Can I mix open source and commercial Chocolatey?</h3>
+                <p>
+                    While you technically can, you need to be very careful, physically separating even the repositories you are using. 
+                    If you end up deploying any packages you've built or acquired with licensed features, those open source nodes will also count as licensed nodes for licensing purposes.
+                </p>
 
-                    <h3 class="mt-4">What happens if we go over the licence count?</h3>
-                    <p>An organization that needs to temporarily go over a license count while you bring up a server before destroying another does not incur a penalty as long as they are back in limits within 24 hours and the average count of licenses is below the threshold.</p>
+                <h3 class="mt-4">What happens if we go over the licence count?</h3>
+                <p>An organization that needs to temporarily go over a license count while you bring up a server before destroying another does not incur a penalty as long as they are back in limits within 24 hours and the average count of licenses is below the threshold.</p>
 
-                    <h3 class="mt-4">Do I install Chocolatey on every machine where I manage software?</h3>
-                    <p>Yes, Chocolatey has a local client install on every machine where you will manage software with Chocolatey.</p>
+                <h3 class="mt-4">Do I install Chocolatey on every machine where I manage software?</h3>
+                <p>Yes, Chocolatey has a local client install on every machine where you will manage software with Chocolatey.</p>
 
-                    <h3 class="mt-4">How can I track the number of nodes we have deployed?</h3>
-                    <p>
-                        We recommend you track the nodes you deploy using your currently reporting tools or deployment schedules so that you are aligned to our licencing agreement.
-                        Our Chocolatey Central Management dashboard does offer the ability for customers to track their node count and deployments.
-                    </p>
+                <h3 class="mt-4">How can I track the number of nodes we have deployed?</h3>
+                <p>
+                    We recommend you track the nodes you deploy using your currently reporting tools or deployment schedules so that you are aligned to our licencing agreement.
+                    Our Chocolatey Central Management dashboard does offer the ability for customers to track their node count and deployments.
+                </p>
 
-                    <h3 class="mt-4">Can I purchase just some of the features?</h3>
-                    <p>Unfortunately not. Chocolatey for Business is more than package management, as it if offers a suite of advanced functionality, support, and deeper technical integrational. With our goals in simplicity, reducing complexity of offerings helps keep costs low. If we separated out the features and sold them individually, the added complexity for us would make the price of individual features the same as our current fully-featured offering.</p>
+                <h3 class="mt-4">Can I purchase just some of the features?</h3>
+                <p>Unfortunately not. Chocolatey for Business is more than package management, as it if offers a suite of advanced functionality, support, and deeper technical integrational. With our goals in simplicity, reducing complexity of offerings helps keep costs low. If we separated out the features and sold them individually, the added complexity for us would make the price of individual features the same as our current fully-featured offering.</p>
 
-                    <h3 class="mt-4">We're an organization, can we deploy Chocolatey Pro?</h3>
-                    <p>
-                        Our Chocolatey Professional edition was developed for home users or community members looking support our open source project. It is a violation of the Pro licensing to use it in an organizational context.
-                        We try to keep our offerings simple, Chocolatey for Business is ideal for organizational use and the cost and time savings far outweigh the investment.
-                    </p>
+                <h3 class="mt-4">We're an organization, can we deploy Chocolatey Pro?</h3>
+                <p>
+                    Our Chocolatey Professional edition was developed for home users or community members looking support our open source project. It is a violation of the Pro licensing to use it in an organizational context.
+                    We try to keep our offerings simple, Chocolatey for Business is ideal for organizational use and the cost and time savings far outweigh the investment.
+                </p>
 
-                    <h3 class="mt-4">What licensing options do you offer?</h3>
-                    <p>We offer both subscription and perpetual licensing. Perpetual offerings are only available for Chocolatey for Business (C4B).</p>
-                </div>
+                <h3 class="mt-4">What licensing options do you offer?</h3>
+                <p>We offer both subscription and perpetual licensing. Perpetual offerings are only available for Chocolatey for Business (C4B).</p>
             </div>
-            @*Purchasing*@
-            <div id="Purchasing" class="col-12 mb-4">
-                <a class="h2 collapsed" data-toggle="collapse" href="#faq-purchasing" role="button" aria-expanded="false" aria-controls="faq-purchasing" title="Purchasing">Purchasing</a>
-                <div class="collapse" id="faq-purchasing">
-                    <hr />
-                    <h3>Can I get an official quote?</h3>
-                    <p>If you are ready to move forward with an official quote or need budgetary pricing simply <a href="@Url.RouteUrl(RouteName.ContactSales)">reach out to our team</a> and we will be back in touch.</p>
+        </div>
+        @*Purchasing*@
+        <div class="mb-4">
+            <a class="h2 collapsed" data-toggle="collapse" href="#faq-purchasing" role="button" aria-expanded="false" aria-controls="faq-purchasing" title="Purchasing">Purchasing</a>
+            <div class="collapse" id="faq-purchasing">
+                <hr />
+                <h3>Can I get an official quote?</h3>
+                <p>If you are ready to move forward with an official quote or need budgetary pricing simply <a href="@Url.RouteUrl(RouteName.ContactSales)">reach out to our team</a> and we will be back in touch.</p>
 
-                    <h3 class="mt-4">Can I purchase through a reseller?</h3>
-                    <p>We do have a <a href="@Url.RouteUrl(RouteName.Partner)#resellers">network of resellers</a> - check with your partner to see if they already have an agreement with Chocolatey. If they do not and you have a preferred partner them simply introduce them to us, and we'll work with them through the process.</p>
+                <h3 class="mt-4">Can I purchase through a reseller?</h3>
+                <p>We do have a <a href="@Url.RouteUrl(RouteName.Partner)#resellers">network of resellers</a> - check with your partner to see if they already have an agreement with Chocolatey. If they do not and you have a preferred partner them simply introduce them to us, and we'll work with them through the process.</p>
 
-                    <h3 class="mt-4">Can I pay by Credit Card, ACH, Wire transfer, check, etc?</h3>
-                    <p>Yes. For organizations, we support many payment methods. If you have general questions and are not already in contact with sales, please <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false">contact sales.</a> Otherwise, please reach out over email/phone.</p>
+                <h3 class="mt-4">Can I pay by Credit Card, ACH, Wire transfer, check, etc?</h3>
+                <p>Yes. For organizations, we support many payment methods. If you have general questions and are not already in contact with sales, please <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false">contact sales.</a> Otherwise, please reach out over email/phone.</p>
 
-                    <h3 class="mt-4">Can you work with my purchasing team to get set-up as a supplier?</h3>
-                    <p>We are happy to engage directly with your purchasing or procurement teams once you are ready to move forward with purchase. This may include the supply of W9, support with on-boarding, and any security or operational questions. Simply <a href="@Url.RouteUrl(RouteName.ContactSales)">contact us</a> with your requirements.</p>
+                <h3 class="mt-4">Can you work with my purchasing team to get set-up as a supplier?</h3>
+                <p>We are happy to engage directly with your purchasing or procurement teams once you are ready to move forward with purchase. This may include the supply of W9, support with on-boarding, and any security or operational questions. Simply <a href="@Url.RouteUrl(RouteName.ContactSales)">contact us</a> with your requirements.</p>
 
-                    <h3 class="mt-4">Where can I obtain a copy of your license agreement?</h3>
-                    <p>For Chocolatey for Business, you can find a copy <a href="@Url.RouteUrl(RouteName.Support)#business-legal">here.</a> Other editions are subject to <a href="https://github.com/chocolatey/choco/blob/master/LICENSE" target="_blank" rel="noreferrer">Apache v2.0 licensing.</a></p>
+                <h3 class="mt-4">Where can I obtain a copy of your license agreement?</h3>
+                <p>For Chocolatey for Business, you can find a copy <a href="@Url.RouteUrl(RouteName.Support)#business-legal">here.</a> Other editions are subject to <a href="https://github.com/chocolatey/choco/blob/master/LICENSE" target="_blank" rel="noreferrer">Apache v2.0 licensing.</a></p>
 
-                    <h3 class="mt-4">How long does it take to get my license?</h3>
-                    <p>Once we have received your order successfully, you will receive your licenses within 1-3 business days.</p>
+                <h3 class="mt-4">How long does it take to get my license?</h3>
+                <p>Once we have received your order successfully, you will receive your licenses within 1-3 business days.</p>
 
-                    <h3 class="mt-4">What is the refund policy?</h3>
-                    <p>For Pro, we provide a full refund the first 30 days. If you are an organization that purchases a starter pack without a trial, you are also granted a 30 day period. Please note we provide business trials so you can know it is right for your organization prior to an annual commitment.</p>
-                </div>
+                <h3 class="mt-4">What is the refund policy?</h3>
+                <p>For Pro, we provide a full refund the first 30 days. If you are an organization that purchases a starter pack without a trial, you are also granted a 30 day period. Please note we provide business trials so you can know it is right for your organization prior to an annual commitment.</p>
             </div>
-            @*Renewals*@
-            <div id="Renewing" class="col-12 mb-4">
-                <a class="h2 collapsed" data-toggle="collapse" href="#faq-renewing" role="button" aria-expanded="false" aria-controls="faq-renewing" title="Renewing">Renewing</a>
-                <div class="collapse" id="faq-renewing">
-                    <hr />
-                    <h3>How do renewals work?</h3>
-                    <p>Typically you would purchase again using the same method as you used previously. The expiry date for the new license will take the old expiration date into account.</p>
-                    <p>
-                        Once you receive the license, you will need to place it on every machine over the old license file. If you have a lot of machines,
-                        we recommend <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-setup-offline-installation"})#exercise-4-create-a-package-for-the-license">creating a package for the license</a> to allow a simple package upgrade.
-                    </p>
+        </div>
+        @*Renewals*@
+        <div class="mb-4">
+            <a class="h2 collapsed" data-toggle="collapse" href="#faq-renewing" role="button" aria-expanded="false" aria-controls="faq-renewing" title="Renewing">Renewing</a>
+            <div class="collapse" id="faq-renewing">
+                <hr />
+                <h3>How do renewals work?</h3>
+                <p>Typically you would purchase again using the same method as you used previously. The expiry date for the new license will take the old expiration date into account.</p>
+                <p>
+                    Once you receive the license, you will need to place it on every machine over the old license file. If you have a lot of machines,
+                    we recommend <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-setup-offline-installation"})#exercise-4-create-a-package-for-the-license">creating a package for the license</a> to allow a simple package upgrade.
+                </p>
 
-                    <h3 class="mt-4">What happens if I don't renew?</h3>
-                    <ul>
-                        <li>Annual: If you have an annual subscription and do not renew it, the commercial features will stop working when the license expires (by default it goes back to open source, but you can <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "chocolatey-configuration"})#flow-control">turn on a feature to make it error</a> if you depend on the security aspects of the commercial edition). Access to support also ceases at the end of your subscription term.</li>
-                        <li>Perpetual: If you have a perpetual license and do not renew the annual maintenance and support, the commercial features will still work, but you will no longer be able to get newer editions of the commercial products, nor will you have access to support.</li>
-                    </ul>
+                <h3 class="mt-4">What happens if I don't renew?</h3>
+                <ul>
+                    <li>Annual: If you have an annual subscription and do not renew it, the commercial features will stop working when the license expires (by default it goes back to open source, but you can <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "chocolatey-configuration"})#flow-control">turn on a feature to make it error</a> if you depend on the security aspects of the commercial edition). Access to support also ceases at the end of your subscription term.</li>
+                    <li>Perpetual: If you have a perpetual license and do not renew the annual maintenance and support, the commercial features will still work, but you will no longer be able to get newer editions of the commercial products, nor will you have access to support.</li>
+                </ul>
 
-                    <h3 class="mt-4">Can you send me a renewal quote?</h3>
-                    <p>Yes, we can for our organizational customers. For organizational customers, we typically email renewal notifications with next steps 30-45 days prior to the license expiration, but sometimes we may not have the right contact or spam filters get in the way. If you are in need of a renewal quote, just <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false">contact our sales team.</a></p>
+                <h3 class="mt-4">Can you send me a renewal quote?</h3>
+                <p>Yes, we can for our organizational customers. For organizational customers, we typically email renewal notifications with next steps 30-45 days prior to the license expiration, but sometimes we may not have the right contact or spam filters get in the way. If you are in need of a renewal quote, just <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false">contact our sales team.</a></p>
 
-                    <h3 class="mt-4">Can I add more nodes?</h3>
-                    <p>Adding more nodes is easy. Simply let us know the number of nodes you would like to add and we provide a quote. We can also add more nodes at any time during your contract and don't have to wait until the renewal date. We can co-term the licensing and pro-rate pricing so you have one simple renewal date.</p>
-                </div>
+                <h3 class="mt-4">Can I add more nodes?</h3>
+                <p>Adding more nodes is easy. Simply let us know the number of nodes you would like to add and we provide a quote. We can also add more nodes at any time during your contract and don't have to wait until the renewal date. We can co-term the licensing and pro-rate pricing so you have one simple renewal date.</p>
             </div>
-            @*Support*@
-            <div id="Support" class="col-12 mb-4">
-                <a class="h2 collapsed" data-toggle="collapse" href="#faq-support" role="button" aria-expanded="false" aria-controls="faq-support" title="Support">Support</a>
-                <div class="collapse" id="faq-support">
-                    <hr />
-                    <h3>How does support work?</h3>
-                    <p>See our <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
+        </div>
+        @*Support*@
+        <div class="mb-4">
+            <a class="h2 collapsed" data-toggle="collapse" href="#faq-support" role="button" aria-expanded="false" aria-controls="faq-support" title="Support">Support</a>
+            <div class="collapse" id="faq-support">
+                <hr />
+                <h3>How does support work?</h3>
+                <p>See our <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
 
-                    <h3 class="mt-4">What levels of support do you offer?</h3>
-                    <p>Please see our <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
-                    <ul>
-                        <li>Pro - included automatically for Professional customers</li>
-                        <li>Business Standard - included automatically for all organizational customers</li>
-                        <li>Business Standard+ - included automatically for all organizational customers with 100 licenses or more</li>
-                        <li>Business Premium - available for larger organizational customers at an additional cost</li>
-                    </ul>
+                <h3 class="mt-4">What levels of support do you offer?</h3>
+                <p>Please see our <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
+                <ul>
+                    <li>Pro - included automatically for Professional customers</li>
+                    <li>Business Standard - included automatically for all organizational customers</li>
+                    <li>Business Standard+ - included automatically for all organizational customers with 100 licenses or more</li>
+                    <li>Business Premium - available for larger organizational customers at an additional cost</li>
+                </ul>
 
-                    <h3 class="mt-4">Do you have 24/7 support available?</h3>
-                    <p>We do for premium customers. Please see the <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
+                <h3 class="mt-4">Do you have 24/7 support available?</h3>
+                <p>We do for premium customers. Please see the <a href="@Url.RouteUrl(RouteName.Support)">support page</a> for details.</p>
 
-                    <h3 class="mt-4">How do I get support for a package?</h3>
-                    <p>We do not have support for packages found on Chocolatey.org - those are considered community packages and should not be used for commercial purposes. Package issues should follow the package triage process. <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "community-packages-disclaimer" })">Read more...</a></p>
-                    <p>While we are able to give tips and pointers on packaging that you create, every piece of software out there is a special snowflake so we are unable to support the packaging of it directly. The only exception to this is if you are a business customer and you opt for professional packaging services.</p>
-                    <p class="mb-0">Professional packaging services can be purchased with a license or at any time simply by reaching out to the sales team. It does carry an additional cost per package - if you already have this, reach out to support. If you haven't already purchased this, you can <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false)">reach out to sales</a> to make payment ahead of time.</p>
-                </div>
+                <h3 class="mt-4">How do I get support for a package?</h3>
+                <p>We do not have support for packages found on Chocolatey.org - those are considered community packages and should not be used for commercial purposes. Package issues should follow the package triage process. <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "community-packages-disclaimer" })">Read more...</a></p>
+                <p>While we are able to give tips and pointers on packaging that you create, every piece of software out there is a special snowflake so we are unable to support the packaging of it directly. The only exception to this is if you are a business customer and you opt for professional packaging services.</p>
+                <p class="mb-0">Professional packaging services can be purchased with a license or at any time simply by reaching out to the sales team. It does carry an additional cost per package - if you already have this, reach out to support. If you haven't already purchased this, you can <a href="@Url.RouteUrl(RouteName.ContactSales)?pipeline=false)">reach out to sales</a> to make payment ahead of time.</p>
             </div>
         </div>
     </div>
@@ -319,5 +316,4 @@
             <td>$68.5125 / $17.7625*</td>
         </tr>
     </tbody>
-</table>
-*@
+</table>*@


### PR DESCRIPTION
In this PR:
* Adds functionality that will automatically expand a collapsed element if the hash is found within the URL, and will also scroll to that element on load
* Adds hash to URL when any collapsed element is clicked on, allowing easy copy/paste
* Functions similarly to how tab navigation currently is implemented.