### PR TITLE
Make typewriter JS compatible with IE

### DIFF
--- a/chocolatey/Website/Content/scss/_search.scss
+++ b/chocolatey/Website/Content/scss/_search.scss
@@ -97,6 +97,8 @@
         top: 100%;
         width: 100%;
         max-width: 539px;
+        left: 0;
+        right: 0;
         z-index: 1;
 
         .arrow-up {

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -428,12 +428,9 @@ try {
 }
 
 // Typewriter animation
-var els = document.querySelectorAll('[data-animate]');
-
-Array.from(els).forEach(animateEl);
-
-function animateEl(el) {
-    var phrases = el.dataset.animate.split(',');
+if ($('.terminal-body').length) {
+    var phrasesSpan = $('.terminal-body span[data-animate]');
+    var phrases = $('.terminal-body span[data-animate]').attr('data-animate').split(',');
     var index = 0;
     var position = 0;
     var currentString = '';
@@ -447,14 +444,15 @@ function animateEl(el) {
             direction = 1;
         } else if (phrases[index][position] !== undefined) {
             currentString = phrases[index].substr(0, position);
+            phrasesSpan = phrasesSpan.html(currentString);
             // if we've arrived at the last position reverse the direction
         } else if (position > 0 && !phrases[index][position]) {
             currentString = phrases[index].substr(0, position);
             direction = -1;
-            el.innerText = currentString;
+            phrasesSpan = phrasesSpan.html(currentString);
             return setTimeout(animate, 2000);
         }
-        el.innerText = currentString;
+        phrasesSpan = phrasesSpan.html(currentString);
         setTimeout(animate, 100);
     }
     animate();

--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -227,7 +227,7 @@
                 <div class="carousel-inner">
                     <div class="carousel-item active">
                         <div class="card">
-                            <div class="card-body p-xl-5 d-xl-flex">
+                            <div class="card-body p-xl-5">
                                 <div class="row align-items-xl-center">
                                     <div class="col-xl-4 text-center">
                                         <div class="w-75 p-5 mx-auto" style="background: #d32323;">
@@ -254,7 +254,7 @@
                     </div>
                     <div class="carousel-item">
                         <div class="card">
-                            <div class="card-body p-xl-5 d-xl-flex">
+                            <div class="card-body p-xl-5">
                                 <div class="row align-items-xl-center">
                                     <div class="col-xl-4 text-center">
                                         <div class="w-75 p-5 mx-auto" style="background: #222;">


### PR DESCRIPTION
The javascript controlling the typewriter animation was not supported
on Internet Explorer. As a result, the typewriter animation and any JS
after that inside the same file was not working properly and
producing errors. The snippet has been rewritten to work on all
browsers, and a result lazy loading images and the global search now
works on IE.

A few styles were updated on the home page and search box to help with
IE display.