### PR TITLE
(GH-728) Reinstate lost moderation permissions

### DIFF
--- a/chocolatey/Website/Content/scss/_base.scss
+++ b/chocolatey/Website/Content/scss/_base.scss
@@ -344,6 +344,13 @@ a + .collapse.show, a + .collapsing {
     top: 2px;
 }
 
+/*z-index*/
+.z-index-1 {
+    z-index: 1;
+}
+.z-index-2 {
+    z-index: 2;
+}
 /*Footer*/
 footer {
     border-top: 5px solid #81b5e2;

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -899,9 +899,28 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                     <p>There are versions of this package awaiting moderation @(Model.Status == PackageStatusType.Submitted ? "(possibly just this one)" : string.Empty). See the <a href="#versionhistory">Version History section</a> below.</p>
                 </div>
             }
-            @if (Model.Status == PackageStatusType.Rejected)
+            @* Maintainers always see the review comments *@
+            @if (Model.Status == PackageStatusType.Approved)
+            {
+                <div class="callout callout-success">
+                    <p>This package was approved @Html.Raw(@reviewerComments) on @Model.ApprovedDate.GetValueOrDefault().ToShortDateString().</p>
+                </div>
+            }
+            @if (Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
             {
                 <div class="callout callout-danger">
+                    <p>This package was submitted prior to moderation and has not been approved. While it is likely safe for you, there is more risk involved.</p>
+                </div>
+            }
+            @if (Model.Listed && Model.Status == PackageStatusType.Exempted)
+            {
+                <div class="callout callout-danger">
+                    This package is exempt from moderation. While it is likely safe for you, there is more risk involved.
+                </div>
+            }
+            @if (Model.Status == PackageStatusType.Rejected)
+            {
+                <div class="callout callout-danger position-relative z-index-1">
                     <p>This package was rejected on @Model.ReviewedDate.GetValueOrDefault().ToShortDateString(). The reviewer @Model.ReviewerUserName has listed the following reason(s):</p>
                     <div class="comments-list-container">
                         <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text >user-unknown</text>}">
@@ -938,25 +957,6 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                     This package is unlisted and hidden from package listings.
                 </div>
             }
-            @* Maintainers always see the review comments *@
-            @if (Model.Status == PackageStatusType.Approved)
-            {
-                <div class="callout callout-success">
-                    <p>This package was approved @Html.Raw(@reviewerComments) on @Model.ApprovedDate.GetValueOrDefault().ToShortDateString().</p>
-                </div>
-            }
-            @if (Model.Listed && Model.Status != PackageStatusType.Approved && Model.Status != PackageStatusType.Exempted)
-            {
-                <div class="callout callout-danger">
-                    <p>This package was submitted prior to moderation and has not been approved. While it is likely safe for you, there is more risk involved.</p>
-                </div>
-            }
-            @if (Model.Listed && Model.Status == PackageStatusType.Exempted)
-            {
-                <div class="callout callout-danger">
-                    This package is exempt from moderation. While it is likely safe for you, there is more risk involved.
-                </div>
-            }
             @if (Model.Status == PackageStatusType.Submitted && !anyPackageRole)
             {
                 if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
@@ -971,205 +971,207 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                     </div>
                 }
             }
-            @*Logged in*@
             else if (anyPackageRole && Model.Status != PackageStatusType.Rejected)
             {
                 if (!string.IsNullOrWhiteSpace(Model.ReviewComments))
                 {
-
-                    <div class="bg-white shadow-sm p-3 mb-3">
+                    <div class="bg-white shadow-sm p-3 mb-3 position-relative z-index-1">
                         <div class="comments-list-container">
                             <div class="comments-list @if (maintainer) {<text> user-maintainer </text>} else if (moderator) {<text> user-moderator</text>} else {<text> user-unknown</text>}">
                                 @Html.Raw(Markdown.ToHtml(Model.ReviewComments.clean_html() ?? string.Empty, MarkdownPipeline))
                             </div>
                         </div>
-                        @if (anyPackageRole)
-                        {
-                            if (Model.Listed || Model.Status == PackageStatusType.Rejected)
-                            {
-                                if (Model.Status == PackageStatusType.Approved)
-                                {
-                                    <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Show Package Communication / Package Test Rerun</button>
-                                }
-                                else
-                                {
-                                    <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Hide Package Review</button>
-                                }
-                            }
-                            <div class="collapse @if (anyPackageRole && Model.Status != PackageStatusType.Approved) {<text>show</text>} " id="add-comment">
-                                @if (moderationRole)
-                                {
-                                    <hr />
-                                    <h3 class="mt-3">Instructions for Review:</h3>
-                                    <ul>
-                                        <li>Reviewers/Moderators must follow review process at <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "moderation" })#reviewer--moderator-process">moderation</a>.
-                                        <li>**Please do not reject a package until the end of the conversation.**</li>
-                                        <li>Check over the powershell scripts - anything look unsafe? Download urls should be official distro</li>
-                                        @if (Model.Status == PackageStatusType.Approved || Model.Status == PackageStatusType.Exempted)
-                                        {
-                                            <li>Moderators: Be very careful about moving a package from approved/exempt into submitted status. A package may be repushed when in this status (no matter how many downloads).</li>
-                                        }
-                                        @if (Model.Dependencies.DependencySets.Any())
-                                        {
-                                            <li>Check dependencies, make sure they are listed on the site (approved if they needed to be moderated first).</li>
-                                        }
-                                        @if (!hasPreviousExistingVersions)
-                                        {
-                                            <li>NOTE! This is a brand new package with no previous existing versions (prereleases do not count): check the name of the package. Does it meet the guidelines? This makes a package immediately rejectable as new package id will be submitted as a different package.</li>
-                                        }
-                                        <li>Check tags</li>
-                                        <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
-                                        <li>Be Nice! :)</li>
-                                    </ul>
-                                }
-                                else
-                                {
-                                    <hr />
-                                    <h3 class="mt-3">Instructions for Comments:</h3>
-                                    <ul>
-                                        <li>You can respond to review comments here.</li>
-                                        <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
-                                        @if (Model.Status == PackageStatusType.Submitted)
-                                        {
-                                            <li>You are also able to self-reject packages that may be out of date or incorrect (if the verifier fails the install). See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">self-reject</a> for more information.</li>
-                                        }
-                                    </ul>
-                                }
-                                @using (Html.BeginForm())
-                                {
-                                    <fieldset class="form">
-                                        <div class="form-field d-label-none">
-                                            @Html.LabelFor(m => m.NewReviewComments)
-                                            @Html.TextAreaFor(m => m.NewReviewComments, new {@class = "text-editor"})
-                                            @Html.ValidationMessageFor(m => m.NewReviewComments)
-                                            <span class="field-hint-message"></span>
-                                        </div>
-                                        <div class="form-field mt-2 font-weight-bold">
-                                            @Html.LabelFor(m => m.Status)
-                                            @if (moderator)
-                                            {
-                                                @Html.DropDownListFor(m => m.Status, statuses)
-                                            }
-                                            else
-                                            {
-                                                @Html.DisplayTextFor(m => m.Status)
-                                            }
-                                            @Html.ValidationMessageFor(m => m.Status)
-                                            <span class="field-hint-message"></span>
-                                        </div>
-                                        @if (moderator || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                        {
-                                            <div class="form-field">
-                                                <input id="RerunTests" name="RerunTests" type="checkbox" value="true" />
-                                                <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun verification tests?</label>
-                                            </div>
-                                        }
-                                        @if (moderator && Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
-                                        {
-                                            <div class="form-field">
-                                                <input id="RerunValidation" name="RerunValidation" type="checkbox" value="true" />
-                                                <label for="RerunValidation" class="for-checkbox" title="Rerun package validation tests.">Rerun validation tests?</label>
-                                            </div>
-                                            <div class="form-field">
-                                                <input id="OverrideValidation" name="OverrideValidation" type="checkbox" value="true" />
-                                                <label for="OverrideValidation" class="for-checkbox" title="Override package validation failures and run tests.">Override validation errors?</label>
-                                            </div>
-                                        }
-                                        @if (moderator)
-                                        {
-                                            <div class="form-field">
-                                                <input id="RerunVirusScanner" name="RerunVirusScanner" type="checkbox" value="true" />
-                                                <label for="RerunVirusScanner" class="for-checkbox" title="Rerun virus scanner to get latest reports.">Rerun virus scanner?</label>
-                                            </div>
-                                        }
-                                        @if (admin & !maintainer)
-                                        {
-                                            <div class="form-field">
-                                                <input id="RerunPackageCacher" name="RerunPackageCacher" type="checkbox" value="true" />
-                                                <label for="RerunPackageCacher" class="for-checkbox" title="Rerun CDN Package Cacher to update cache.">Rerun CDN Package Cacher?</label>
-                                            </div>
-                                        }
-                                        @if (moderationRole)
-                                        {
-                                            <div class="form-field">
-                                                <input id="SendEmail" name="SendEmail" type="checkbox" checked="checked" value="true" />
-                                                <label for="SendEmail" class="for-checkbox" title="Send an email to the maintainer? They won't receive notice of your action otherwise. With normal review operations, it is normal to leave this checked.">Send Maintainer email?</label>
-                                            </div>
-                                            <div class="form-field">
-                                                <input id="ChangeSubmittedStatus" name="ChangeSubmittedStatus" type="checkbox" checked="checked" value="true" />
-                                                <label for="ChangeSubmittedStatus" class="for-checkbox" title="If just rerunning tests or leaving a non-flagging comment (e.g. not requiring changes by the maintainer(s)), uncheck this box.">If Submitted status, require maintainer to make changes?</label>
-                                            </div>
-                                        }
-                                        else if (maintainer && Model.Status == PackageStatusType.Submitted && (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing))
-                                        {
-                                            <div class="form-field">
-                                                <input id="MaintainerReject" name="MaintainerReject" type="checkbox" value="true" onclick="if (this.checked) { return confirm('Are you sure? It is not normal to reject a package.'); }" />
-                                                <label for="MaintainerReject" class="for-checkbox" title="If the download link is always the same and you have some older versions under review, the older versions can be rejected without issue. Under normal circumstances this should not be used.">Reject Package? Not for <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">normal scenarios or obsoletion</a>.</label>
-                                            </div>
-                                        }
-                                        @Html.ValidationSummary(true)
-                                        @if (moderationRole)
-                                        {
-                                            <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-trusted" aria-expanded="false" aria-controls="test-trusted">Show Trusted Section</button>
-                                            <div class="collapse form-field" id="test-trusted">
-                                                <ul class="mb-0 mt-3">
-                                                    <li>Trusted package ids are packages where we have built trust in the package maintainer(s).</li>
-                                                    <li>This usually happens after we have seen several iterations of a package without issues.</li>
-                                                    <li>All package *versions* submitted from now on will automatically be approved.</li>
-                                                    <li>This also happens when maintainer is also the author of the software.</li>
-                                                    @if (moderator)
-                                                    {
-                                                        <li>Use with care.</li>
-                                                        <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
-                                                    }
-                                                </ul>
-                                                @if (moderator)
-                                                {
-                                                    @Html.EditorFor(m => m.IsTrusted)
-                                                    <label for="IsTrusted" class="mt-2 mb-0 pb-2">Trust this package id?</label>
-                                                }
-                                                else
-                                                {
-                                                    var trustedText = @Model.IsTrusted ? "is trusted" : "follows normal workflow";
-                                                    <p class="mt-2 mb-0 pb-2">This package @trustedText.</p>
-                                                }
-                                            </div>
-                                            <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-exemptions" aria-expanded="false" aria-controls="test-exemptions">Show Testing Exemption Section</button>
-                                            <div class="collapse form-field" id="test-exemptions">
-                                                <ul class="mb-0 mt-3">
-                                                    <li>Exempting a package id from testing requires a reason.</li>
-                                                    @if (moderator)
-                                                    {
-                                                        <li>Use with care.</li>
-                                                        <li>Typically this is done when a package is installing drivers the testing computer does not have</li>
-                                                        <li>This is NOT done just because a maintainer doesn't know how to make a program silent with Auto Hot Key.</li>
-                                                        <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
-                                                    }
-                                                </ul>
-                                                @if (moderator)
-                                                {
-                                                    @Html.EditorFor(m => m.IsExemptedFromVerification)
-                                                    <label for="IsExemptedFromVerification" class="mt-2 mb-3">Exempt the package from verification testing?</label>
-                                                    <div class="form-field d-label-none pb-2">
-                                                        @Html.LabelFor(m => m.ExemptedFromVerificationReason)
-                                                        @Html.TextAreaFor(m => m.ExemptedFromVerificationReason, new {@class = "text-editor"})
-                                                        @Html.ValidationMessageFor(m => m.ExemptedFromVerificationReason)
-                                                    </div>
-                                                }
-                                                else
-                                                {
-                                                    var testInformation = @Model.IsExemptedFromVerification ? "skips automatic verification (testing)" : "follows normal workflow";
-                                                    <p class="mt-2 mb-0 pb-2">This package @testInformation.</p>
-                                                }
-                                            </div>
-                                        }
-                                        <button class="btn btn-success d-block mt-2" type="submit" value="Save" title="Save Changes"><i class="fas fa-save" alt="Save"></i> Save</button>
-                                    </fieldset>
-                                }
-                            </div>
-                        }
                     </div>
                 }
+            }
+            @*Logged in*@
+            @if (anyPackageRole)
+            {
+                <div class="bg-white shadow-sm p-3 mb-3 mt-n3 position-relative z-index-2">
+                    @if (Model.Listed || Model.Status == PackageStatusType.Rejected)
+                    {
+
+                        if (Model.Status == PackageStatusType.Approved)
+                        {
+                            <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Show Package Communication / Package Test Rerun</button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-secondary d-flex mx-auto mt-3" type="button" data-toggle="collapse" data-target="#add-comment" aria-expanded="false" aria-controls="add-comment">Hide Package Review</button>
+                        }
+                    }
+                    <div class="collapse @if (Model.Status != PackageStatusType.Approved) {<text>show</text>} " id="add-comment">
+                        @if (moderationRole)
+                        {
+                            <hr />
+                            <h3 class="mt-3">Instructions for Review:</h3>
+                            <ul>
+                                <li>Reviewers/Moderators must follow review process at <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "moderation" })#reviewer--moderator-process">moderation</a>.
+                                <li>**Please do not reject a package until the end of the conversation.**</li>
+                                <li>Check over the powershell scripts - anything look unsafe? Download urls should be official distro</li>
+                                @if (Model.Status == PackageStatusType.Approved || Model.Status == PackageStatusType.Exempted)
+                                {
+                                    <li>Moderators: Be very careful about moving a package from approved/exempt into submitted status. A package may be repushed when in this status (no matter how many downloads).</li>
+                                }
+                                @if (Model.Dependencies.DependencySets.Any())
+                                {
+                                    <li>Check dependencies, make sure they are listed on the site (approved if they needed to be moderated first).</li>
+                                }
+                                @if (!hasPreviousExistingVersions)
+                                {
+                                    <li>NOTE! This is a brand new package with no previous existing versions (prereleases do not count): check the name of the package. Does it meet the guidelines? This makes a package immediately rejectable as new package id will be submitted as a different package.</li>
+                                }
+                                <li>Check tags</li>
+                                <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
+                                <li>Be Nice! :)</li>
+                            </ul>
+                        }
+                        else
+                        {
+                            <hr />
+                            <h3 class="mt-3">Instructions for Comments:</h3>
+                            <ul>
+                                <li>You can respond to review comments here.</li>
+                                <li>Keep in mind this is publicly visible, so do not share any sensitive data or anything you wouldn't want to share with the world.</li>
+                                @if (Model.Status == PackageStatusType.Submitted)
+                                {
+                                    <li>You are also able to self-reject packages that may be out of date or incorrect (if the verifier fails the install). See <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">self-reject</a> for more information.</li>
+                                }
+                            </ul>
+                        }
+                        @using (Html.BeginForm())
+                        {
+                            <fieldset class="form">
+                                <div class="form-field d-label-none">
+                                    @Html.LabelFor(m => m.NewReviewComments)
+                                    @Html.TextAreaFor(m => m.NewReviewComments, new {@class = "text-editor"})
+                                    @Html.ValidationMessageFor(m => m.NewReviewComments)
+                                    <span class="field-hint-message"></span>
+                                </div>
+                                <div class="form-field mt-2 font-weight-bold">
+                                    @Html.LabelFor(m => m.Status)
+                                    @if (moderator)
+                                    {
+                                        @Html.DropDownListFor(m => m.Status, statuses)
+                                    }
+                                    else
+                                    {
+                                        @Html.DisplayTextFor(m => m.Status)
+                                    }
+                                    @Html.ValidationMessageFor(m => m.Status)
+                                    <span class="field-hint-message"></span>
+                                </div>
+                                @if (moderator || Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing)
+                                {
+                                    <div class="form-field">
+                                        <input id="RerunTests" name="RerunTests" type="checkbox" value="true" />
+                                        <label for="RerunTests" class="for-checkbox" title="Only necessary if there was a mistake in the test run. A package repush will trigger test reruns.">Rerun verification tests?</label>
+                                    </div>
+                                }
+                                @if (moderator && Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing)
+                                {
+                                    <div class="form-field">
+                                        <input id="RerunValidation" name="RerunValidation" type="checkbox" value="true" />
+                                        <label for="RerunValidation" class="for-checkbox" title="Rerun package validation tests.">Rerun validation tests?</label>
+                                    </div>
+                                    <div class="form-field">
+                                        <input id="OverrideValidation" name="OverrideValidation" type="checkbox" value="true" />
+                                        <label for="OverrideValidation" class="for-checkbox" title="Override package validation failures and run tests.">Override validation errors?</label>
+                                    </div>
+                                }
+                                @if (moderator)
+                                {
+                                    <div class="form-field">
+                                        <input id="RerunVirusScanner" name="RerunVirusScanner" type="checkbox" value="true" />
+                                        <label for="RerunVirusScanner" class="for-checkbox" title="Rerun virus scanner to get latest reports.">Rerun virus scanner?</label>
+                                    </div>
+                                }
+                                @if (admin & !maintainer)
+                                {
+                                    <div class="form-field">
+                                        <input id="RerunPackageCacher" name="RerunPackageCacher" type="checkbox" value="true" />
+                                        <label for="RerunPackageCacher" class="for-checkbox" title="Rerun Customer CDN cacher to update cache.">Rerun package CDN cacher?</label>
+                                    </div>
+                                }
+                                @if (moderationRole)
+                                {
+                                    <div class="form-field">
+                                        <input id="SendEmail" name="SendEmail" type="checkbox" checked="checked" value="true" />
+                                        <label for="SendEmail" class="for-checkbox" title="Send an email to the maintainer? They won't receive notice of your action otherwise. With normal review operations, it is normal to leave this checked.">Send Maintainer email?</label>
+                                    </div>
+                                    <div class="form-field">
+                                        <input id="ChangeSubmittedStatus" name="ChangeSubmittedStatus" type="checkbox" checked="checked" value="true" />
+                                        <label for="ChangeSubmittedStatus" class="for-checkbox" title="If just rerunning tests or leaving a non-flagging comment (e.g. not requiring changes by the maintainer(s)), uncheck this box.">If Submitted status, require maintainer to make changes?</label>
+                                    </div>
+                                }
+                                else if (maintainer && Model.Status == PackageStatusType.Submitted && (Model.PackageTestResultsStatus == PackageAutomatedReviewResultStatusType.Failing || Model.PackageValidationResultStatus == PackageAutomatedReviewResultStatusType.Failing))
+                                {
+                                    <div class="form-field">
+                                        <input id="MaintainerReject" name="MaintainerReject" type="checkbox" value="true" onclick="if (this.checked) { return confirm('Are you sure? It is not normal to reject a package.'); }" />
+                                        <label for="MaintainerReject" class="for-checkbox" title="If the download link is always the same and you have some older versions under review, the older versions can be rejected without issue. Under normal circumstances this should not be used.">Reject Package? Not for <a href="@Url.RouteUrl(RouteName.FAQ)#how-do-i-self-reject-a-package">normal scenarios or obsoletion</a>.</label>
+                                    </div>
+                                }
+                                @Html.ValidationSummary(true)
+                                @if (moderationRole)
+                                {
+                                    <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-trusted" aria-expanded="false" aria-controls="test-trusted">Show Trusted Section</button>
+                                    <div class="collapse form-field" id="test-trusted">
+                                        <ul class="mb-0 mt-3">
+                                            <li>Trusted package ids are packages where we have built trust in the package maintainer(s).</li>
+                                            <li>This usually happens after we have seen several iterations of a package without issues.</li>
+                                            <li>All package *versions* submitted from now on will automatically be approved.</li>
+                                            <li>This also happens when maintainer is also the author of the software.</li>
+                                            @if (moderator)
+                                            {
+                                                <li>Use with care.</li>
+                                                <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
+                                            }
+                                        </ul>
+                                        @if (moderator)
+                                        {
+                                            @Html.EditorFor(m => m.IsTrusted)
+                                            <label for="IsTrusted" class="mt-2 mb-0 pb-2">Trust this package id?</label>
+                                        }
+                                        else
+                                        {
+                                            var trustedText = @Model.IsTrusted ? "is trusted" : "follows normal workflow";
+                                            <p class="mt-2 mb-0 pb-2">This package @trustedText.</p>
+                                        }
+                                    </div>
+                                    <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-exemptions" aria-expanded="false" aria-controls="test-exemptions">Show Testing Exemption Section</button>
+                                    <div class="collapse form-field" id="test-exemptions">
+                                        <ul class="mb-0 mt-3">
+                                            <li>Exempting a package id from testing requires a reason.</li>
+                                            @if (moderator)
+                                            {
+                                                <li>Use with care.</li>
+                                                <li>Typically this is done when a package is installing drivers the testing computer does not have</li>
+                                                <li>This is NOT done just because a maintainer doesn't know how to make a program silent with Auto Hot Key.</li>
+                                                <li>Use "Save" below to make this change. You may want to uncheck Send Email.</li>
+                                            }
+                                        </ul>
+                                        @if (moderator)
+                                        {
+                                            @Html.EditorFor(m => m.IsExemptedFromVerification)
+                                            <label for="IsExemptedFromVerification" class="mt-2 mb-3">Exempt the package from verification testing?</label>
+                                            <div class="form-field d-label-none pb-2">
+                                                @Html.LabelFor(m => m.ExemptedFromVerificationReason)
+                                                @Html.TextAreaFor(m => m.ExemptedFromVerificationReason, new {@class = "text-editor"})
+                                                @Html.ValidationMessageFor(m => m.ExemptedFromVerificationReason)
+                                            </div>
+                                        }
+                                        else
+                                        {
+                                            var testInformation = @Model.IsExemptedFromVerification ? "skips automatic verification (testing)" : "follows normal workflow";
+                                            <p class="mt-2 mb-0 pb-2">This package @testInformation.</p>
+                                        }
+                                    </div>
+                                }
+                                <button class="btn btn-success d-block mt-2" type="submit" value="Save" title="Save Changes"><i class="fas fa-save" alt="Save"></i> Save</button>
+                            </fieldset>
+                        }
+                    </div>
+                </div>
             }
             @*  Description  *@
             <div class="mb-4">


### PR DESCRIPTION
With the new redesign, some permissions of maintainers and
moderaters were lost. After comparing the DisplayPackage.cshmtl now to
how it was before the redesign, a few changes have been made to the
layout to ensure these permissions were reinstated. The overall
look/feel remains the same.

Fixes #728 