### PR TITLE
(GH-736, GH-682) Show files with no content and add checksums

### DIFF
--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -1297,13 +1297,13 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                         var fileCount = Model.Files.Count();
                         foreach (var file in Model.Files)
                         {
-                            if (!string.IsNullOrWhiteSpace(file.FileContent))
-                            {
-                                var packageFile = "file-path-" + Path.GetFileName(file.FilePath.ToLower()).Replace(".", "-").Replace(" ", string.Empty) + "-" + random.Next();
-                                var alwaysExpand = file.FilePath.ToLower().Contains("chocolateyinstall.ps1") || file.FilePath.ToLower().Contains("chocolateyuninstall.ps1") || file.FilePath.ToLower().Contains("chocolateybeforemodify.ps1") || file.FilePath.ToLower().Contains("verification.txt") || file.FilePath.ToLower().Contains("license.txt");
-                                var expandFile = expandForModeration && fileCount <= 9 || expandForModeration && alwaysExpand;
-                                <div class="mb-1">
-                                    @if (expandFile)
+                            var packageFile = "file-path-" + Path.GetFileName(file.FilePath.ToLower()).Replace(".", "-").Replace(" ", string.Empty) + "-" + random.Next();
+                            var alwaysExpand = file.FilePath.ToLower().Contains("chocolateyinstall.ps1") || file.FilePath.ToLower().Contains("chocolateyuninstall.ps1") || file.FilePath.ToLower().Contains("chocolateybeforemodify.ps1") || file.FilePath.ToLower().Contains("verification.txt") || file.FilePath.ToLower().Contains("license.txt");
+                            var expandFile = expandForModeration && fileCount <= 9 || expandForModeration && alwaysExpand;
+                            <div class="mb-1">
+                                @if (!string.IsNullOrWhiteSpace(file.FileContent))
+                                {
+                                    if (expandFile)
                                     {
                                         <button type="button" class="btn btn-sm btn-secondary mr-2" data-toggle="collapse" data-target=".@packageFile" role="button" aria-expanded="true">Hide</button>
                                     }
@@ -1311,12 +1311,12 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                     {
                                         <button type="button" class="btn btn-sm btn-secondary mr-2" data-toggle="collapse" data-target=".@packageFile" role="button" aria-expanded="false">Show</button>
                                     }
-                                    @file.FilePath
-                                    <div class="@packageFile collapse @if(expandFile){<text>show</text>}">
-                                        <pre class="@if(expandFile){<text>line-numbers</text>}"><code class="@if(expandFile){<text>language-powershell</text>}">@file.FileContent</code></pre>
-                                    </div>
+                                }
+                                @file.FilePath
+                                <div class="@packageFile collapse @if(expandFile){<text>show</text>}">
+                                    <pre class="@if(expandFile){<text>line-numbers</text>}"><code class="@if(expandFile){<text>language-powershell</text>}">@file.FileContent</code></pre>
                                 </div>
-                            }
+                            </div>
                         }
                     }
                 </div>

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -58,7 +58,7 @@
     <add key="Gallery:ModeratorEmail" value="nobody@nowhere.com" />
     <add key="Gallery:ContactUsEmail" value="nobody@nowhere.com" />
     <add key="Gallery:PackageFileTextExtensions" value="ps1,psm1,psd1,txt,md,cmd,config,conf,bat,sh,json,js,xml,xdt,ini,iss,ahk,au3,sql,conf,vbs,inf,nuspec,template,reg,cs,manifest,csv" />
-    <add key="Gallery:PackageFileChecksumExtensions" value="exe,7z,zip,msi,dll,gz,rar,ttf,so,msp,mst,msu,sfx,iso,vsix" />
+    <add key="Gallery:PackageFileChecksumExtensions" value="exe,7z,zip,msi,dll,gz,rar,ttf,so,msp,mst,msu,sfx,iso,vsix,msix,msixbundle,appx,appxbundle,tar,xz,bz2,zst,pyc,pyo,pyd,pyz,pywz,bin" />
     <add key="Gallery:UseCaching" value="true" />
     <add key="Gallery:HostImages" value="true" />
     <add key="Gallery:PackageOperationsUserKey" value="0" />


### PR DESCRIPTION
With the refactoring of the Files section to use razor syntax instead
of javascript, one piece of content was wrapped inside of a
`(!string.IsNullOrWhiteSpace(file.FileContent))` that was not supposed
to be. This was causing files with no content to not be displayed. The
Files section has been adjusted slightly so that files with no content
will still be displayed.

Now:
![emptyFile](https://user-images.githubusercontent.com/42750725/69065513-831b8100-09e5-11ea-859d-b0752b43d22e.png)

After enabling multiple file types to show a checksum, such as the .msixbundle file:
![checksum](https://user-images.githubusercontent.com/42750725/69145656-c3393d00-0a93-11ea-8227-13b6b3afe84c.png)


Fixes #736
Fixes #682 