### PR TITLE
(GH-750) Remove jobs for updating database 

### DIFF
--- a/chocolatey/Website/App_Start/AppActivator.cs
+++ b/chocolatey/Website/App_Start/AppActivator.cs
@@ -1,15 +1,15 @@
-﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
 // authors/contributors from ChocolateyGallery
 // at https://github.com/chocolatey/chocolatey.org,
-// and the authors/contributors of NuGetGallery 
+// and the authors/contributors of NuGetGallery
 // at https://github.com/NuGet/NuGetGallery
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,7 +74,7 @@ namespace NuGetGallery
             ViewEngines.Engines.Add(new CSharpRazorViewEngine());
 
             RegisterGlobalFilters(GlobalFilters.Filters);
-            
+
             Routes.RegisterRoutes(RouteTable.Routes);
 
 #if !DEBUG
@@ -98,7 +98,7 @@ namespace NuGetGallery
         {
             var jobs = new List<IJob>();
             var indexer = DependencyResolver.Current.GetService<IIndexingService>();
-          
+
             if (indexer != null)
             {
                 indexer.RegisterBackgroundJobs(jobs);
@@ -124,8 +124,8 @@ namespace NuGetGallery
         private static void DbMigratorPostStart()
         {
             var dbMigrator = new DbMigrator(new MigrationsConfiguration());
-            // After upgrading to EF 4.3 and MiniProfile 1.9, there is a bug that causes several 
-            // 'Invalid object name 'dbo.__MigrationHistory' to be thrown when the database is first created; 
+            // After upgrading to EF 4.3 and MiniProfile 1.9, there is a bug that causes several
+            // 'Invalid object name 'dbo.__MigrationHistory' to be thrown when the database is first created;
             // it seems these can safely be ignored, and the database will still be created.
             dbMigrator.Update();
         }

--- a/chocolatey/Website/App_Start/AppActivator.cs
+++ b/chocolatey/Website/App_Start/AppActivator.cs
@@ -104,8 +104,15 @@ namespace NuGetGallery
                 indexer.RegisterBackgroundJobs(jobs);
             }
 
-            jobs.Add(new UpdateStatisticsJob(TimeSpan.FromMinutes(15), () => new EntitiesContext(), timeout: TimeSpan.FromMinutes(30)));
-            jobs.Add(new WorkItemCleanupJob(TimeSpan.FromDays(1), () => new EntitiesContext(), timeout: TimeSpan.FromDays(4)));
+            if (ConfigurationManager.AppSettings.Get("EnablePackageStatisticsBackgroundJob").Equals(bool.TrueString, StringComparison.InvariantCultureIgnoreCase))
+            {
+                jobs.Add(new UpdateStatisticsJob(TimeSpan.FromMinutes(15), () => new EntitiesContext(), timeout: TimeSpan.FromMinutes(30)));
+            }
+
+            if (ConfigurationManager.AppSettings.Get("EnableWorkItemsBackgroundJob").Equals(bool.TrueString, StringComparison.InvariantCultureIgnoreCase))
+            {
+                jobs.Add(new WorkItemCleanupJob(TimeSpan.FromDays(1), () => new EntitiesContext(), timeout: TimeSpan.FromDays(4)));
+            }
 
             var jobCoordinator = new WebFarmJobCoordinator(new EntityWorkItemRepository(() => new EntitiesContext()));
             _jobManager = new JobManager(jobs, jobCoordinator)

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -67,6 +67,8 @@
 
     <add key="ForceSSL" value="false" />
     <add key="DisqusShortname" value="chocolatey-local" />
+    <add key="EnablePackageStatisticsBackgroundJob" value="false" />
+    <add key="EnableWorkItemsBackgroundJob" value="false" />
 
     <add key="Enyim.Caching.Diagnostics.LogPath" value="c:\enyimcaching.log" />
     <add key="Cache.IsCacheEnabled" value="true" />

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -20,11 +20,11 @@
   </configSections>
   <appSettings>
     <add key="webpages:Version" value="1.0.0.0" />
-    <add key="ClientValidationEnabled" value="true" /> 
+    <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <!-- https://docs.microsoft.com/en-us/aspnet/whitepapers/mvc3-release-notes#0.1__Toc274034230 -
-         there is a known issue that causes Forms Authentication to always redirect 
-         to /Account/Login, ignoring what is set in web.config authentication 
+         there is a known issue that causes Forms Authentication to always redirect
+         to /Account/Login, ignoring what is set in web.config authentication
     -->
     <add key="autoFormsAuthentication" value="false" />
     <add key="enableSimpleMembership" value="false" />
@@ -64,7 +64,7 @@
     <add key="Gallery:PackageOperationsUserKey" value="0" />
     <add key="Gallery:ScanResultsKey" value="12345" />
     <add key="Gallery:StudentDiscount" value="https://somewhere.com" />
-    
+
     <add key="ForceSSL" value="false" />
     <add key="DisqusShortname" value="chocolatey-local" />
 
@@ -72,7 +72,7 @@
     <add key="Cache.IsCacheEnabled" value="true" />
     <add key="Cache.IsCacheDependencyManagementEnabled" value="false" />
     <add key="Cache.CacheToUse" value="memory" />
-    <add key="Cache.DistributedCacheServers" value="127.0.0.1:11211" /> 
+    <add key="Cache.DistributedCacheServers" value="127.0.0.1:11211" />
     <add key="Cache.CacheSpecificData" value="MinPoolSize=10;MaxPoolSize=30" />
     <add key="appharbor.commit_id" value="e6d26435a78649505303f2c2fd948a4c7601003e" />
     <add key="appharbor.worker_name" value="web1" />


### PR DESCRIPTION
These background jobs are prone to stopping without any warning, with
the only way to start them again properly being to restart the website.
This is far from ideal, and as such, the decision has been taken to
remove them from the site, and instead run them elsewhere.

Fixes #750 