### PR TITLE
(GH-752) Prevent double "Preview" in text editor toolbar

### DIFF
--- a/chocolatey/Website/Scripts/packages/package-details.js
+++ b/chocolatey/Website/Scripts/packages/package-details.js
@@ -110,6 +110,6 @@ $(function () {
             toolbar: ["bold", "italic", "heading", "strikethrough", "|", "quote", "unordered-list", "ordered-list", "code", "|", "link", "image", "|", "side-by-side", "fullscreen", "|", "preview"]
         });
         easymde.render();
-        $('<span> Preview</span>').insertAfter('.editor-toolbar .fa-eye').parent().addClass('font-weight-bold text-primary');
+        $('<span> Preview</span>').insertAfter($(this).next().find('.fa-eye')).parent().addClass('font-weight-bold text-primary');
     });
 });


### PR DESCRIPTION
Inside of any text editor that takes advantage of the EasyMDE library, an eye with the word "Preview" is shown. In cases where there are more than one of these text editors on a page, the word "Preview" is being appended twice.

The code for appending the word "Preview" has been slightly modified to address this problem. Since the code for this is inside an `each()` loop, the identifier needs to originate from `$(this)`, or else the error above will occur.

Fixes #752 