### PR TITLE
(GH-756) Make internal doc links contain hyphens

### DIFF
--- a/chocolatey/Website/Controllers/DocumentationController.cs
+++ b/chocolatey/Website/Controllers/DocumentationController.cs
@@ -117,7 +117,32 @@ namespace NuGetGallery.Controllers
                 MatchCollection urlOnePatternMatches = Regex.Matches(contents, urlOnePattern);
                 foreach (Match match in urlOnePatternMatches)
                 {
-                    contents = contents.Replace(match.Value, "[" + match.Groups[1].Value + "](/docs/" + match.Groups[2].Value.ToLower() + ")");
+                    var hyphenatedValue = new StringBuilder();
+
+                    Char previousChar = '^';
+                    foreach (var valueChar in match.Groups[2].Value.ToString())
+                    {
+                        // Filenames that contain both a "-" and camel casing
+                        if (match.Groups[2].Value.Contains("-") && Char.IsLower(previousChar) && Char.IsUpper(valueChar))
+                        {
+                            hyphenatedValue.Append("-");
+                        }
+
+                        if (Char.IsUpper(valueChar) && hyphenatedValue.Length != 0 && !Char.IsUpper(previousChar) && !match.Groups[2].Value.Contains("-"))
+                        {
+                            hyphenatedValue.Append("-");
+                        }
+
+                        if (Char.IsDigit(valueChar) && !Char.IsDigit(previousChar) && hyphenatedValue.Length != 0)
+                        {
+                            hyphenatedValue.Append("-");
+                        }
+
+                        previousChar = valueChar;
+                        hyphenatedValue.Append(valueChar.to_string());
+                    }
+
+                    contents = contents.Replace(match.Value, "[" + match.Groups[1].Value + "](/docs/" + hyphenatedValue.ToString().ToLower() + ")");
                 }
 
                 var urlTwoPattern = @"\[(.*?)\]\((.*?)\)";


### PR DESCRIPTION
Some of the internal links inside the documentation files do not contain hyphens in between words when they are supposed to. The links still work how they are, but they are pointing to a different url than what has already been established.

A new method has been added to handle adding these hyphens in between words much similarly as file names are being handled. This ensures all urls are consistent throughout the documentation area.

For example, if the link below was referenced within a documentation file (as like on the home page, second link), it would be rendered as https://chocolatey.org/docs/gettingstarted#what-is-chocolatey and no left side navigation is highlighted.
![doc2](https://user-images.githubusercontent.com/42750725/70146027-f7e9ee80-1666-11ea-8717-d480e7790d5b.png)


Now with the fix (correct link) https://chocolatey.org/docs/getting-started#what-is-chocolatey and the left side navigation highlighted.
![doc3](https://user-images.githubusercontent.com/42750725/70146069-105a0900-1667-11ea-88d0-c01b2f588bd3.png)

Fixes #756 