### PR TITLE
Configure Tags as NOT_ANALYZED

### DIFF
--- a/nugetgallery/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/nugetgallery/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -133,7 +133,7 @@ namespace NuGetGallery
 
             if (!String.IsNullOrEmpty(package.Tags))
             {
-                field = new Field("Tags", package.Tags, Field.Store.NO, Field.Index.ANALYZED);
+                field = new Field("Tags", package.Tags, Field.Store.NO, Field.Index.NOT_ANALYZED);
                 field.SetBoost(0.8f);
                 document.Add(field);
             }


### PR DESCRIPTION
When clicking on a tag from the package list, you are shown the search results for a query on tag with the term of the tag you clicked on. However, because tags are indexed with analysis on, any tags with a hyphen in will be indexed as multiple words.

This is the result:
https://twitter.com/sqldbawithbeard/status/1202348325808361474

This change would result in these becoming exact matches.