### PR TITLE
(GH-762)(GH-761) Lucene Index Fixes and Enhancements

### DIFF
--- a/chocolatey/Website/App_Start/ContainerBinding.cs
+++ b/chocolatey/Website/App_Start/ContainerBinding.cs
@@ -37,6 +37,8 @@ namespace NuGetGallery
     /// </summary>
     public class ContainerBinding
     {
+        private const int LUCENE_TIMEOUT_SECONDS = 720;
+
         /// <summary>
         ///   Loads the module into the kernel.
         /// </summary>
@@ -81,7 +83,7 @@ namespace NuGetGallery
             container.RegisterPerWebRequest<IPackageService, PackageService>();
             container.RegisterPerWebRequest<ICryptographyService, CryptographyService>();
 
-            container.Register<IIndexingService>(() => new LuceneIndexingService(container.GetInstance<IEntityRepository<Package>>(), configuration.IndexContainsAllVersions), Lifestyle.Singleton);
+            container.Register<IIndexingService>(() => new LuceneIndexingService(() => new EntitiesContext(LUCENE_TIMEOUT_SECONDS), configuration.IndexContainsAllVersions), Lifestyle.Singleton);
             container.Register<IFormsAuthenticationService, FormsAuthenticationService>(Lifestyle.Singleton);
 
             container.RegisterPerWebRequest<IControllerFactory, NuGetControllerFactory>();

--- a/chocolatey/Website/DataServices/FeedServiceBase.cs
+++ b/chocolatey/Website/DataServices/FeedServiceBase.cs
@@ -224,7 +224,7 @@ namespace NuGetGallery
             return packages.Search(searchTerm);
         }
        
-         private IQueryable<Package> GetResultsFromSearchService(SearchFilter searchFilter)
+         internal IQueryable<Package> GetResultsFromSearchService(SearchFilter searchFilter)
          {
              var result = SearchService.Search(searchFilter);
  

--- a/chocolatey/Website/DataServices/V2Feed.svc.cs
+++ b/chocolatey/Website/DataServices/V2Feed.svc.cs
@@ -35,7 +35,6 @@ namespace NuGetGallery
     public class V2Feed : FeedServiceBase<V2FeedPackage>
     {
         private const int FeedVersion = 2;
-
         private const int DEFAULT_CACHE_TIME_SECONDS_V2FEED = 60;
 
         public V2Feed()

--- a/chocolatey/Website/DataServices/V2SubmittedFeed.svc.cs
+++ b/chocolatey/Website/DataServices/V2SubmittedFeed.svc.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery
         public IQueryable<V2FeedPackage> Search(string searchTerm, string targetFramework, bool includePrerelease)
         {
             var packages = PackageRepo.GetAll().Where(p => p.StatusForDatabase == PackageStatusType.Submitted.GetDescriptionOrValue());
-            var packageVersions = SearchCore(packages, searchTerm, targetFramework, includePrerelease, SearchFilter.Empty(), useCache:false).ToV2FeedPackageQuery(GetSiteRoot()).ToList();
+            var packageVersions = SearchCore(packages, searchTerm, targetFramework, includePrerelease, SearchFilter.Empty(isValid:true), useCache:false).ToV2FeedPackageQuery(GetSiteRoot()).ToList();
 
             if (!includePrerelease)
             {

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -35,12 +35,14 @@ namespace NuGetGallery
 {
     public class LuceneIndexingService : IIndexingService
     {
+        private const int LUCENE_CACHE_REBUILD_HOURS = 24;
+        private const int LUCENE_UPDATE_JOB_FREQUENCY_MINUTES = 10;
+        private const int LUCENE_UPDATE_JOB_TIMEOUT_MINUTES = 8;
         private readonly string _rejectedStatus = PackageStatusType.Rejected.GetDescriptionOrValue();
         private readonly Func<EntitiesContext> _contextThunk;
         private static readonly object IndexWriterLock = new object();
 
-        private static readonly TimeSpan IndexRecreateInterval = TimeSpan.FromHours(3);
-
+        private static readonly TimeSpan IndexRecreateInterval = TimeSpan.FromHours(LUCENE_CACHE_REBUILD_HOURS);
         private static readonly ConcurrentDictionary<Directory, IndexWriter> WriterCache = new ConcurrentDictionary<Directory, IndexWriter>();
 
         private readonly Directory _directory;
@@ -339,8 +341,8 @@ namespace NuGetGallery
             {
                 jobs.Add(
                     new LuceneIndexingJob(
-                        frequence: TimeSpan.FromMinutes(6),
-                        timeout: TimeSpan.FromMinutes(5),
+                        frequence: TimeSpan.FromMinutes(LUCENE_UPDATE_JOB_FREQUENCY_MINUTES),
+                        timeout: TimeSpan.FromMinutes(LUCENE_UPDATE_JOB_TIMEOUT_MINUTES),
                         indexingService: this));
             }
         }

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -35,6 +35,7 @@ namespace NuGetGallery
 {
     public class LuceneIndexingService : IIndexingService
     {
+        private readonly Func<EntitiesContext> _contextThunk;
         private static readonly object IndexWriterLock = new object();
 
         private static readonly TimeSpan IndexRecreateInterval = TimeSpan.FromHours(3);
@@ -51,9 +52,14 @@ namespace NuGetGallery
 
         public bool IsLocal { get { return true; } }
 
-        public LuceneIndexingService(IEntityRepository<Package> packageSource, bool indexContainsAllVersions)
+        public LuceneIndexingService(Func<EntitiesContext> contextThunk, bool indexContainsAllVersions)
         {
-            _packageRepository = packageSource;
+            if (contextThunk == null)
+            {
+                throw new ArgumentNullException("contextThunk");
+            }
+            _contextThunk = contextThunk;
+
             _indexContainsAllVersions = indexContainsAllVersions;
             _directory = new LuceneFileSystem(LuceneCommon.IndexDirectory);
             _getShouldAutoUpdate = () => true;

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -108,6 +108,14 @@ namespace NuGetGallery
 
         public void UpdatePackage(Package package)
         {
+            if (_indexContainsAllVersions)
+            {
+                //just update everything since the last write time
+                UpdateIndex(forceRefresh: false);
+                return;
+            }
+
+            // when we only store the latest, we can run the rest of this
             if (_getShouldAutoUpdate())
             {
                 var packageRegistrationKey = package.PackageRegistrationKey;

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -41,10 +41,8 @@ namespace NuGetGallery
         private readonly string _rejectedStatus = PackageStatusType.Rejected.GetDescriptionOrValue();
         private readonly Func<EntitiesContext> _contextThunk;
         private static readonly object IndexWriterLock = new object();
-
         private static readonly TimeSpan IndexRecreateInterval = TimeSpan.FromHours(LUCENE_CACHE_REBUILD_HOURS);
         private static readonly ConcurrentDictionary<Directory, IndexWriter> WriterCache = new ConcurrentDictionary<Directory, IndexWriter>();
-
         private readonly Directory _directory;
         private IndexWriter _indexWriter;
         private readonly bool _indexContainsAllVersions;
@@ -77,6 +75,7 @@ namespace NuGetGallery
 
         public void UpdateIndex(bool forceRefresh)
         {
+            // TODO could we rebuild the lucene cache somewhere and then remove the current and replace it with the updated one
             // Always do it if we're asked to "force" a refresh (i.e. manually triggered)
             // Otherwise, no-op unless we're supporting background search indexing.
             if (forceRefresh || _getShouldAutoUpdate())

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -19,7 +19,8 @@ namespace NuGetGallery
         private static readonly string[] Fields = new[] { "Id", "Title", "Tags", "Description", "Authors", "Owners" };
         private Lucene.Net.Store.Directory _directory;
 
-        public LuceneSearchService() : this(containsAllVersions: false)
+        public LuceneSearchService()
+            : this(containsAllVersions: false)
         {
         }
 
@@ -77,7 +78,7 @@ namespace NuGetGallery
             {
                 filter = new QueryWrapperFilter(new TermQuery(new Term("InIndex", Boolean.TrueString)));
             }
-            
+
             var results = searcher.Search(query, filter: filter, n: numRecords, sort: new Sort(GetSortField(searchFilter)));
 
             if (results.TotalHits == 0 || searchFilter.CountOnly)
@@ -126,7 +127,7 @@ namespace NuGetGallery
             if (!string.IsNullOrEmpty(doc.Get("DownloadCacheDate"))) downloadCacheDate = DateTime.Parse(doc.Get("DownloadCacheDate"), CultureInfo.InvariantCulture);
             DateTime? packageScanResultDate = null;
             if (!string.IsNullOrEmpty(doc.Get("PackageScanResultDate"))) packageScanResultDate = DateTime.Parse(doc.Get("PackageScanResultDate"), CultureInfo.InvariantCulture);
-    
+
             var owners = doc.Get("FlattenedOwners")
                             .split_safe(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                             .Select(o => new User { Username = o })
@@ -195,7 +196,7 @@ namespace NuGetGallery
                 PackageCleanupResultDate = packageCleanupResultDate,
                 ReviewedDate = reviewedDate,
                 ApprovedDate = approvedDate,
-                ReviewedBy = new User { Username = doc.Get("PackageReviewer") }, 
+                ReviewedBy = new User { Username = doc.Get("PackageReviewer") },
                 DownloadCacheStatusForDatabase = doc.Get("DownloadCacheStatus"),
                 DownloadCacheDate = downloadCacheDate,
                 DownloadCache = doc.Get("DownloadCache"),
@@ -256,7 +257,7 @@ namespace NuGetGallery
             startsIdQuery.Boost = 6.0f;
             var wildCardIdQuery = new WildcardQuery(new Term("Id-Exact", "*" + escapedSearchTerm + "*"));
             wildCardIdQuery.Boost = 3.0f;
-            
+
             var exactTitleQuery = new TermQuery(new Term("Title-Exact", escapedSearchTerm));
             exactTitleQuery.Boost = 6.5f;
             var startsTitleQuery = new WildcardQuery(new Term("Title-Exact", escapedSearchTerm + "*"));
@@ -288,18 +289,19 @@ namespace NuGetGallery
                     wildCardQuery.Add(wildCardTermQuery, Occur.MUST);
                 }
             }
-            
+
             // Create an OR of all the queries that we have
             var combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery, relatedIdQuery, exactTitleQuery, startsIdQuery, startsTitleQuery, wildCardIdQuery, wildCardTitleQuery, conjuctionQuery, wildCardQuery });
 
             if (onlySearchById)
             {
                 combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery, relatedIdQuery, startsIdQuery, wildCardIdQuery, wildCardQuery });
-            } else if (onlySearchByAuthor || onlySearchByTag)
+            }
+            else if (onlySearchByAuthor || onlySearchByTag)
             {
                 combinedQuery = conjuctionQuery.Combine(new Query[] { wildCardQuery });
             }
-            
+
             //if (searchFilter.SortProperty == SortProperty.Relevance)
             //{
             //    // If searching by relevance, boost scores by download count.
@@ -323,7 +325,7 @@ namespace NuGetGallery
             switch (searchFilter.SortProperty)
             {
                 case SortProperty.Relevance:
-                  return SortField.FIELD_SCORE;
+                    return SortField.FIELD_SCORE;
                 case SortProperty.DisplayName:
                     return new SortField("DisplayName", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
                 case SortProperty.DownloadCount:

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -269,9 +269,7 @@ namespace NuGetGallery
 
             foreach (var term in terms)
             {
-                var localTerm = term.to_lower_invariant();
-                
-                localTerm = term.Replace("id\\:", string.Empty).Replace("author\\:", string.Empty).Replace("tag\\:", string.Empty);
+                var localTerm = Escape(term).Replace("id\\:", string.Empty).Replace("author\\:", string.Empty).Replace("tag\\:", string.Empty);
                 var termQuery = queryParser.Parse(localTerm);
                 conjuctionQuery.Add(termQuery, Occur.MUST);
                 disjunctionQuery.Add(termQuery, Occur.SHOULD);

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -75,7 +75,7 @@ namespace NuGetGallery
 
             if (searchFilter.IncludeAllVersions)
             {
-                filter = new QueryWrapperFilter(new TermQuery(new Term("Listed", Boolean.TrueString)));
+                filter = new QueryWrapperFilter(new TermQuery(new Term("InIndex", Boolean.TrueString)));
             }
             
             var results = searcher.Search(query, filter: filter, n: numRecords, sort: new Sort(GetSortField(searchFilter)));

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -237,10 +237,6 @@ namespace NuGetGallery
             var disjunctionQuery = new BooleanQuery();
             disjunctionQuery.Boost = 0.1f;
 
-            // Suffix wildcard search e.g. jquer*
-            var wildCardQuery = new BooleanQuery();
-            wildCardQuery.Boost = 0.5f;
-
             // Escape the entire term we use for exact searches.
             var escapedSearchTerm = Escape(searchFilter.SearchTerm).Replace("id\\:", string.Empty).Replace("author\\:", string.Empty).Replace("tag\\:", string.Empty);
 
@@ -265,7 +261,12 @@ namespace NuGetGallery
             var wildCardTitleQuery = new WildcardQuery(new Term("Title-Exact", "*" + escapedSearchTerm + "*"));
             wildCardTitleQuery.Boost = 2.5f;
 
-            foreach (var term in GetSearchTerms(searchFilter.SearchTerm))
+            // Suffix wildcard search e.g. jquer*
+            var wildCardQuery = new BooleanQuery();
+            wildCardQuery.Boost = 0.5f;
+
+            var terms = GetSearchTerms(searchFilter.SearchTerm).ToList();
+            foreach (var term in terms)
             {
                 var localTerm = term.to_lower_invariant();
                 onlySearchById = localTerm.StartsWith("id\\:");

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -333,24 +333,6 @@ namespace NuGetGallery
                 case SortProperty.Recent:
                     return new SortField("PublishedDate", SortField.LONG, reverse: true);
             }
-            switch (searchFilter.SortModeration)
-            {
-                case SortModeration.SubmittedStatus:
-                    return new SortField("SubmittedStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.PendingStatus:
-                    return new SortField("PendingStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.WaitingStatus:
-                    return new SortField("WaitingStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.RespondedStatus:
-                    return new SortField("RespondedStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.ReadyStatus:
-                    return new SortField("ReadyStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.UpdatedStatus:
-                    return new SortField("UpdatedStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.UnknownStatus:
-                    return new SortField("UnknownStatus", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
-                case SortModeration.AllStatuses:
-                    return new SortField("AllStatuses", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
             }
 
             return SortField.FIELD_SCORE;

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -332,7 +332,8 @@ namespace NuGetGallery
                     return new SortField("DownloadCount", SortField.INT, reverse: true);
                 case SortProperty.Recent:
                     return new SortField("PublishedDate", SortField.LONG, reverse: true);
-            }
+                case SortProperty.Version:
+                    return new SortField("Version", SortField.LONG, reverse: true);
             }
 
             return SortField.FIELD_SCORE;

--- a/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -289,7 +289,11 @@ namespace NuGetGallery
             // Create an OR of all the queries that we have
             var combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery, relatedIdQuery, exactTitleQuery, startsIdQuery, startsTitleQuery, wildCardIdQuery, wildCardTitleQuery, conjuctionQuery, wildCardQuery });
 
-            if (onlySearchById)
+            if (onlySearchByExactId)
+            {
+                combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery });
+            }
+            else if (onlySearchById)
             {
                 combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery, relatedIdQuery, startsIdQuery, wildCardIdQuery, wildCardQuery });
             }

--- a/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -129,6 +129,7 @@ namespace NuGetGallery
             document.Add(new Field("IsLatestStable", Package.IsLatestStable.to_string(), Field.Store.YES, Field.Index.NOT_ANALYZED));
             document.Add(new Field("IsPrerelease", Package.IsPrerelease.to_string(), Field.Store.YES, Field.Index.NOT_ANALYZED));
             document.Add(new Field("Listed", Package.Listed.to_string(), Field.Store.YES, Field.Index.NOT_ANALYZED));
+            document.Add(new Field("InIndex", "True", Field.Store.YES, Field.Index.NOT_ANALYZED));
 
             document.Add(new Field("Language", Package.Language.to_string(), Field.Store.YES, Field.Index.NO));
             document.Add(new Field("LastUpdated", Package.LastUpdated.ToString(CultureInfo.InvariantCulture), Field.Store.YES, Field.Index.NO));

--- a/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery
             //id fields
             document.Add(new Field("Id-Original", Package.PackageRegistration.Id, Field.Store.YES, Field.Index.NO));
 
-            var field = new Field("Id-Exact", Package.PackageRegistration.Id.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED);
+            var field = new Field("Id-Exact", Package.PackageRegistration.Id.ToLowerInvariant(), Field.Store.YES, Field.Index.NOT_ANALYZED);
             field.Boost = 4.5f;
             document.Add(field);
             
@@ -74,7 +74,7 @@ namespace NuGetGallery
             field.Boost = 0.25f;
             document.Add(field);
 
-            document.Add(new Field("Version", Package.Version.to_string(), Field.Store.YES, Field.Index.NO));
+            document.Add(new Field("Version", Package.Version.to_string(), Field.Store.YES, Field.Index.NOT_ANALYZED));
 
             // title fields
             // If an element does not have a Title, fall back to Id, same as the website.
@@ -82,7 +82,7 @@ namespace NuGetGallery
                                    ? Package.PackageRegistration.Id
                                    : Package.Title;
 
-            field = new Field("Title-Exact", workingTitle.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED);
+            field = new Field("Title-Exact", workingTitle.ToLowerInvariant(), Field.Store.YES, Field.Index.NOT_ANALYZED);
             field.Boost = 4.0f;
             document.Add(field);
 

--- a/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/chocolatey/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -184,8 +184,7 @@ namespace NuGetGallery
             if (Package.SupportedFrameworks.AnySafe())
             {
                 string joinedFrameworks = string.Join(";", Package.SupportedFrameworks.Select(f => f.FrameworkName));
-                document.Add(new Field("JoinedSupportedFrameworks", joinedFrameworks, Field.Store.YES,
-                                       Field.Index.NO));
+                document.Add(new Field("JoinedSupportedFrameworks", joinedFrameworks, Field.Store.YES, Field.Index.NO));
             }
 
             string displayName = String.IsNullOrEmpty(Package.Title) ? Package.PackageRegistration.Id : Package.Title;

--- a/chocolatey/Website/Services/PackageService.cs
+++ b/chocolatey/Website/Services/PackageService.cs
@@ -1204,7 +1204,7 @@ namespace NuGetGallery
 
         private void NotifyIndexingService()
         {
-            indexingSvc.UpdateIndex(forceRefresh:true);
+            indexingSvc.UpdateIndex(forceRefresh:false);
         }
 
         private void NotifyIndexingService(Package package)

--- a/chocolatey/Website/Services/SearchFilter.cs
+++ b/chocolatey/Website/Services/SearchFilter.cs
@@ -12,6 +12,10 @@ namespace NuGetGallery
 
         public bool IncludePrerelease { get; set; }
 
+        public bool ByIdOnly { get; set; }
+
+        public bool ExactIdOnly { get; set; }
+
         public SortProperty SortProperty { get; set; }
 
         public SortDirection SortDirection { get; set; }
@@ -51,6 +55,7 @@ namespace NuGetGallery
         DownloadCount,
         DisplayName,
         Recent,
+        Version
     }
 
     public enum SortDirection

--- a/chocolatey/Website/Services/SearchFilter.cs
+++ b/chocolatey/Website/Services/SearchFilter.cs
@@ -29,11 +29,11 @@ namespace NuGetGallery
         public bool IsValid { get; set; }
         public SearchFilterInvalidReason FilterInvalidReason { get; set; }
 
-        public static SearchFilter Empty()
+        public static SearchFilter Empty(bool isValid = false)
         {
             return new SearchFilter
             {
-                IsValid = false,
+                IsValid = isValid,
                 FilterInvalidReason = SearchFilterInvalidReason.Unknown,
             };
         }


### PR DESCRIPTION
There were a number of issues identified in the move to store all results in the index (#754). Most of these are addressed by this request:

* Set timeout for connection itself to allow for more than 110  seconds to finish querying out all records
* Update Lucene Index Job with better timings and timeouts
* Adjust package index fields.
* Don't force a full rebuild every package addition/update
* Store all unlisted as those should also be returned in some instances
* Move FindPackagesById to use the index when storing all results
* Fix the search filters a bit with the id, tags, author precursors
* Ensure index is updated properly when a package is updated and storing all results

Fixes #761
Fixes #762