### PR TITLE
(GH-783) Fix broken link to moderator queue

### DIFF
--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -399,7 +399,13 @@ namespace NuGetGallery
                 // If we are searching for something, sort by relevance.
                 sortOrder = q.IsEmpty() ? Constants.PopularitySortOrder : Constants.RelevanceSortOrder;
             }
-            
+
+            if (String.IsNullOrEmpty(moderationStatus))
+            {
+                // If no moderation status is specified, default to All Statuses
+                moderationStatus = Constants.AllModerationStatuses;
+            }
+
             int totalHits = 0;
             int updatedPackagesCount = 0;
             int respondedPackagesCount = 0;


### PR DESCRIPTION
Currently, if a user is to go to https://chocolatey.org/packages?q=&moderatorQueue=true they will be hit with a 404 page.

This is due to the moderationStatus filter being null. Now, if the filter is null then it will be defaulted to "AllModerationStatuses" which will show all the packages in moderation as expected. With this in place, the link above now works as intended.

Fixes #783