### PR TITLE
(GH-788) Fix link to shim feature page 

### DIFF
--- a/chocolatey/Website/Views/Pages/Pricing.cshtml
+++ b/chocolatey/Website/Views/Pages/Pricing.cshtml
@@ -1,4 +1,4 @@
-@{
+﻿@{
     ViewBag.Title = "Pricing";
     Bundles.Reference("Content/dist/chocolatey.slim.css");
     Bundles.Reference("Content/pages.css");
@@ -25,7 +25,7 @@
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "create-packages"})">Create Packages</a></li>
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-host-feed"})">Host Your Own Package Repository</a></li>
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "features-infrastructure-automation"})">Integration with Other Tools</a></li>
-                            <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "features-shims"})">Package Shims</a></li>
+                            <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "features-shim"})">Package Shims</a></li>
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "commands-upgrade"})">Upgrade all software with one command</a></li>
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "helpers-reference"})">30+ Build-in PowerShell Functions</a></li>
                             <li class="list-group-item"><span class="fas fa-check"></span> <a href="@Url.RouteUrl(RouteName.Docs, new {docName = "how-to-create-extensions"})">Package Extensions</a></li>

--- a/chocolatey/Website/Views/Pages/Pricing.cshtml
+++ b/chocolatey/Website/Views/Pages/Pricing.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewBag.Title = "Pricing";
     Bundles.Reference("Content/dist/chocolatey.slim.css");
     Bundles.Reference("Content/pages.css");
@@ -158,7 +158,7 @@
 
                 <h3 class="mt-4">Can I mix open source and commercial Chocolatey?</h3>
                 <p>
-                    While you technically can, you need to be very careful, physically separating even the repositories you are using. 
+                    While you technically can, you need to be very careful, physically separating even the repositories you are using.
                     If you end up deploying any packages you've built or acquired with licensed features, those open source nodes will also count as licensed nodes for licensing purposes.
                 </p>
 


### PR DESCRIPTION
Changed name of route from features-shims to feature-shim as used in
other place throughout the site.

Fixes #788 