### PR TITLE
(GH-790) Prevent 4 spaces from converting to code blocks

### DIFF
--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Markdig
 @using NuGetGallery
+@using Markdig.Parsers
 @model DisplayPackageViewModel
 @{
     Layout = "~/Views/Shared/NewsletterLayout.cshtml";
@@ -15,7 +16,7 @@
     Bundles.Reference("Scripts/easymde");
     Bundles.Reference("Scripts/closeable");
 
-    var MarkdownPipeline = new MarkdownPipelineBuilder()
+    var markdownPipelineBuilder = new MarkdownPipelineBuilder()
                  .UseSoftlineBreakAsHardlineBreak()
                  .UseAutoLinks()
                  .UseGridTables()
@@ -24,8 +25,11 @@
                  .UseEmphasisExtras()
                  .UseNoFollowLinks()
                  .UseCustomContainers()
-                 .UseBootstrap()
-                 .Build();
+                 .UseBootstrap();
+
+    markdownPipelineBuilder.BlockParsers.TryRemove<IndentedCodeBlockParser>();
+
+    var MarkdownPipeline = markdownPipelineBuilder.Build();
 
     var statuses = Model.Status.GetEnumerationItems().ToList();
     var packageImage = Url.ImageUrl(Model.Id, Model.Version, Model.IconUrl);

--- a/chocolatey/Website/Views/Packages/VerifyPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/VerifyPackage.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Markdig
-@using NuGetGallery;
+@using NuGetGallery
+@using Markdig.Parsers
 @model VerifyPackageViewModel
 @{
     ViewBag.Tab = "Upload Your Package";
@@ -10,7 +11,7 @@
     Bundles.Reference("Scripts/packages");
     Bundles.Reference("Scripts/prism");
 
-    var MarkdownPipeline = new MarkdownPipelineBuilder()
+    var markdownPipelineBuilder = new MarkdownPipelineBuilder()
                  .UseSoftlineBreakAsHardlineBreak()
                  .UseAutoLinks()
                  .UseGridTables()
@@ -19,8 +20,11 @@
                  .UseEmphasisExtras()
                  .UseNoFollowLinks()
                  .UseCustomContainers()
-                 .UseBootstrap()
-                 .Build();
+                 .UseBootstrap();
+
+    markdownPipelineBuilder.BlockParsers.TryRemove<IndentedCodeBlockParser>();
+
+    var MarkdownPipeline = markdownPipelineBuilder.Build();
 }
 
 <section id="account" class="container py-3 py-md-5">

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -147,8 +147,8 @@
     <Reference Include="Lucene.Net.Contrib.SpellChecker">
       <HintPath>..\..\packages\Lucene.Net.Contrib.3.0.3\lib\net40\Lucene.Net.Contrib.SpellChecker.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig, Version=0.15.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Markdig.0.15.6\lib\net40\Markdig.dll</HintPath>
+    <Reference Include="Markdig, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Markdig.0.18.0\lib\net40\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="MarkdownSharp, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MarkdownSharp.2.0.5\lib\net40\MarkdownSharp.dll</HintPath>

--- a/chocolatey/Website/packages.config
+++ b/chocolatey/Website/packages.config
@@ -24,7 +24,7 @@
   <package id="log4net" version="2.0.5" targetFramework="net40" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net40" />
-  <package id="Markdig" version="0.15.6" targetFramework="net40" />
+  <package id="Markdig" version="0.18.0" targetFramework="net40" />
   <package id="MarkdownSharp" version="2.0.5" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />


### PR DESCRIPTION
In the package description area, currently 4 spaces is being interpreted as a code block when that is the unintended outcome. The changes here will disable this feature. This is implemented on both the Verify Package page and the Display Package page.

Reference on a similar issue: https://github.com/lunet-io/markdig/issues/348 
Package in pictures: https://chocolatey.org/packages/powershell-preview#description

Before:
![code-block](https://user-images.githubusercontent.com/42750725/71671987-49ef6400-2d3a-11ea-9f5a-373d02754bee.png)

After:
![code-block-after](https://user-images.githubusercontent.com/42750725/71671995-52479f00-2d3a-11ea-8387-5e31ece3756e.png)
