### PR TITLE
Enable TLS 1.2 & 1.3 Icon Downloading

### DIFF
--- a/chocolatey/Website/App_Start/AppActivator.cs
+++ b/chocolatey/Website/App_Start/AppActivator.cs
@@ -22,6 +22,7 @@ using System.Configuration;
 using System.Data.Entity;
 using System.Data.Entity.Migrations;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
@@ -50,6 +51,19 @@ namespace NuGetGallery
         public static void PreStart()
         {
             MiniProfilerPreStart();
+
+            // Enable TLS 1.3, TLS 1.2, TLS 1.1, and TLS 1.0 for all WebClients. Specifically, for
+            // Services\ImageFileService.cs#DownloadImage() to allow downloading package icons served from CDNs that
+            // have disabled TLS <1.2 from .NET 4.0. This also disables SSLv3, if it was enabled by default.
+            SecurityProtocolType enabledProtocols = 0;
+            foreach (int protocol in new int[] { 12288, 3072, 768, 192 })
+            {
+                if (Enum.IsDefined(typeof(SecurityProtocolType), protocol))
+                {
+                    enabledProtocols |= (SecurityProtocolType)protocol;
+                }
+            }
+            ServicePointManager.SecurityProtocol = enabledProtocols;
         }
 
         public static void PostStart()


### PR DESCRIPTION
Some CDNs and iconUrl servers have disabled TLS versions below 1.2, causing problems for the WebClient in .NET 4.0 (see reports about the Statically CDN failing for icons).

Targeting a newer version of .NET should should remove the need for this, but for now this should fix #652 .

I've tested this change on Windows 10 with the Statically CDN to confirm that it resolved the problem.