### PR TITLE
Package area bug fixes and seo enchancements

### DIFF
--- a/chocolatey/Website/Views/Packages/ContactOwners.cshtml
+++ b/chocolatey/Website/Views/Packages/ContactOwners.cshtml
@@ -83,6 +83,12 @@
                     </fieldset>
                 }
             }
+            else
+            {
+               <div class="callout callout-danger">
+                    <p><strong>Note:</strong> All the owners of this package have chosen not to receive email communication.</p>
+                </div>
+            }
         </div>
     </div>
 </section>

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -1401,7 +1401,7 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                     {
                                         fileScanHighlight = "virus-scan-medium";
                                     }
-                                    else if (fileScan.Positives > 5 && fileScan.Positives < 11)
+                                    else if (fileScan.Positives > 10)
                                     {
                                         fileScanHighlight = "virus-scan-dark";
                                     }

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -760,7 +760,7 @@ choco upgrade @Model.Id.ToLower() -y --source=&quot;'STEP 3 URL'&quot; [other op
                                     <p>Add this to a PowerShell script or use a Batch script with tools and in places where you are calling directly to Chocolatey. If you are integrating, keep in mind enhanced exit codes.</p>
                                     <p>If you do use a PowerShell script, use the following to ensure bad exit codes are shown as failures:</p>
 <pre class="language-powershell line-numbers border py-3"><code>
-choco upgrade @Model.Id.ToLower() -y --source="'STEP 3 URL'" 
+choco upgrade @Model.Id.ToLower() -y --source="'STEP 3 URL'"
 $exitCode = $LASTEXITCODE
 
 Write-Verbose "Exit code was $exitCode"
@@ -1401,7 +1401,7 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                     {
                                         fileScanHighlight = "virus-scan-medium";
                                     }
-                                    else if (fileScan.Positives > 10)
+                                    else
                                     {
                                         fileScanHighlight = "virus-scan-dark";
                                     }

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -107,6 +107,11 @@
     {
         <meta name="robots" content="noindex" />
     }
+    @if (!string.IsNullOrWhiteSpace(Model.Summary))
+    {
+        <meta property="og:description" content="@Model.Summary" />
+        <meta property="description" content="@Model.Summary" />
+    }
 }
 @if (!User.Identity.IsAuthenticated)
 {


### PR DESCRIPTION
This PR contains:
* Enhancements to the SEO on any package page. Now when sharing the package through a link, the package description will appear instead of a generalized description about Chocolatey.
* Fixes issues of seeing a blank screen when trying to contact an owner of package that has opted out of email
* Fixes virus scan results highlighting over 10

Fixes #801 
Fixes #819 