### PR TITLE
Merge pull request #821 from designxsteph/GH-731

### DIFF
--- a/chocolatey/Website/Controllers/PackagesController.cs
+++ b/chocolatey/Website/Controllers/PackagesController.cs
@@ -464,7 +464,7 @@ namespace NuGetGallery
                 switch (searchFilter.SortModeration)
                 {
                     case SortModeration.AllStatuses:
-                        packageVersions = packageVersions.Where(p => !p.IsPrerelease).Where(p => p.StatusForDatabase == unknownStatus || p.StatusForDatabase == null);
+                        packageVersions = packageVersions.Where(p => !p.IsPrerelease).Where(p => p.StatusForDatabase != unknownStatus && p.StatusForDatabase != null);
                         packagesToShow = resubmittedPackages.Union(respondedPackages).Union(unreviewedPackages).Union(pendingAutoReviewPackages).Union(waitingForMaintainerPackages);
                         switch (searchFilter.SortProperty)
                         {
@@ -626,11 +626,6 @@ namespace NuGetGallery
                 if ((searchFilter.Skip + searchFilter.Take) >= packagesToShow.Count() & string.IsNullOrWhiteSpace(q)) packagesToShow = packagesToShow.Union(packageVersions.OrderByDescending(pv => pv.PackageRegistration.DownloadCount).ToList());
 
                 packagesToShow = packagesToShow.Skip(searchFilter.Skip).Take(searchFilter.Take);
-
-                if (!string.IsNullOrWhiteSpace(q) && (searchFilter.SortModeration.Equals(SortModeration.UnknownStatus) || searchFilter.SortModeration.Equals(SortModeration.AllStatuses)) || searchFilter.SortModeration.Equals(SortModeration.UnknownStatus))
-                {
-                    totalHits = totalHits - unknownPackagesCount;
-                }
             }
             else
             {

--- a/chocolatey/Website/Views/Packages/ListPackages.cshtml
+++ b/chocolatey/Website/Views/Packages/ListPackages.cshtml
@@ -118,8 +118,6 @@
                                         <button type="submit" name="moderationStatus" value="@Constants.ReadyModerationStatus" class="bg-transparent border-0 btn-link text-dark">@moderationReadyPackageCount Ready</button>
                                         <span>|</span>
                                         <button type="submit" name="moderationStatus" value="@Constants.PendingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationPendingAutoReviewPackageCount Pending</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.UnknownModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationUnknownPackageCount Unreviewed</button>
                                         <input type="hidden" name="prerelease" value="false" />
                                         <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
                                     </fieldset>
@@ -193,7 +191,6 @@
                                             @ViewHelpers.Option(Constants.WaitingModerationStatus, "Waiting", Model.ModerationStatus)
                                             @ViewHelpers.Option(Constants.RespondedModerationStatus, "Responded", Model.ModerationStatus)
                                             @ViewHelpers.Option(Constants.ReadyModerationStatus, "Ready", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.UnknownModerationStatus, "Unknown", Model.ModerationStatus)
                                         </select>
                                     </div>
                                     <div class="col-sm mb-2 mb-sm-0">


### PR DESCRIPTION
This removes unknown packages from the total moderation count and from
being viewed from the "all-statuses" filter while in the moderation
queue. This has been done to reduce confusion on the total number of
packages in moderation. These packages are still visible but only by
following the url below:

https://chocolatey.org/packages?q=&moderatorQueue=true&moderationStatus=unknown-status

Adds to #731 