### PR TITLE
Merge pull request #822 from designxsteph/virus-scan

### DIFF
--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -1401,7 +1401,7 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                     {
                                         fileScanHighlight = "virus-scan-medium";
                                     }
-                                    else
+                                    else if (fileScan.Positives > 10)
                                     {
                                         fileScanHighlight = "virus-scan-dark";
                                     }


### PR DESCRIPTION
The line on `1404` must be an `else if` clause so that package virus scan results of `0` are not detected and highlighted in red. With this fix, only results that are greater than `10` will be highlighted in red.

Fixes #819 