### PR TITLE
 (GH-818) Prevent CSRF attack on Logout

### DIFF
--- a/chocolatey/Website/Content/scss/_navigation.scss
+++ b/chocolatey/Website/Content/scss/_navigation.scss
@@ -163,7 +163,7 @@
                 border-color: $primary;
             }
 
-            a {
+            a, .btn-link {
                 display: flex;
                 flex-direction: column;
 

--- a/chocolatey/Website/Controllers/AuthenticationController.cs
+++ b/chocolatey/Website/Controllers/AuthenticationController.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
             return View();
         }
 
-        [HttpPost, RequireHttpsAppHarbor]
+        [HttpPost, RequireHttpsAppHarbor, ValidateAntiForgeryToken]
         public virtual ActionResult LogOn(SignInRequest request, string returnUrl)
         {
             // TODO: modify the Object.cshtml partial to make the first text box autofocus, or use additional metadata
@@ -77,6 +77,7 @@ namespace NuGetGallery
             return SafeRedirect(returnUrl);
         }
 
+        [HttpPost, RequireHttpsAppHarbor, ValidateAntiForgeryToken]
         public virtual ActionResult LogOff(string returnUrl)
         {
             formsAuthSvc.SignOut();

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -458,20 +458,16 @@ function getCookie(name) {
     return false;
 }
 
-// Set Login Cookie
+// Set Login/Logoff Navigation
 $(function () {
-    var acount = $(".ux_account");
-    var action = $(".ux_account_action");
+    var uxLogoff = $('.ux_logoff');
+    var uxLogin = $('.ux_login');
     if (getCookie('.ChocolateyGalleryAuthentication')) {
-        acount.html('<span class="fas fa-cogs" alt="Account"></span><span>Account</span>');
-        acount.prop('href', '/account');
-        action.html('<span class="fas fa-sign-out-alt" alt="Log Off"></span><span>Log Off</span>');
-        action.prop('href', '/users/account/LogOff');
+        uxLogoff.removeClass('d-none');
+        uxLogin.addClass('d-none');
     } else {
-        acount.html('<span class="fas fa-sign-in-alt" alt="Login"></span><span>Login</span>');
-        acount.prop('href', '/users/account/LogOn');
-        action.html('<span class="fas fa-user-plus" alt="Signup"></span><span>Signup</span>');
-        action.prop('href', '/account/Register');
+        uxLogoff.addClass('d-none');
+        uxLogin.removeClass('d-none');
     }
 });
 

--- a/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
@@ -1,34 +1,33 @@
 ﻿<nav class="navbar bg-white border-bottom d-flex">
     <div class="container">
-        <ul>
+        <ul class="mr-0 d-none d-sm-flex">
             @if (ViewContext.RouteData.Values["Action"].Equals("DisplayPackage"))
             {
-                <li class="d-none d-sm-flex">
+                <li>
                     <a href="@Url.RouteUrl(RouteName.ListPackages)">
                         <span class="fas fa-download" alt="Packages"></span>
                         <span>Packages</span>
                     </a>
                 </li>
             }
-            @if (!User.Identity.IsAuthenticated)
-            {
+        </ul>
+        <ul class="ux_login ml-sm-0 d-none">
             <li>
-                <a class="ux_account_action" href="@Url.Action(MVC.Users.Register())">
+                <a href="@Url.Action(MVC.Users.Register())">
                     <span class="fas fa-user-plus" alt="Signup"></span>
                     <span>Signup</span>
                 </a>
             </li>
             <li>
-                <a class="ux_account" href="@Url.LogOn()">
+                <a href="@Url.LogOn()">
                     <span class="fas fa-sign-in-alt" alt="Login"></span>
                     <span>Login</span>
                 </a>
             </li>
-            }
-            else
-            {
+        </ul>
+        <ul class="ux_logoff ml-sm-0 d-none">
             <li>
-                <a class="ux_account" href="@Url.Action(MVC.Users.Account())">
+                <a href="@Url.Action(MVC.Users.Account())">
                     <span class="fas fa-cogs" alt="Account"></span>
                     <span>Account</span>
                 </a>
@@ -51,7 +50,6 @@
                     </fieldset>
                 }
             </li>
-            }
         </ul>
     </div>
 </nav>

--- a/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
@@ -40,10 +40,16 @@
                 </a>
             </li>
             <li>
-                <a class="ux_account_action" href="@Url.LogOff()">
-                    <span class="fas fa-sign-out-alt" alt="Log Off"></span>
-                    <span>Log Off</span>
-                </a>
+                @using (Html.BeginForm("LogOff", "Authentication", FormMethod.Post))
+                {
+                    <fieldset class="form">
+                        @Html.AntiForgeryToken()
+                        <button class="btn btn-link align-items-center p-0 text-decoration-none" type="submit">
+                            <span class="fas fa-sign-out-alt" alt="Log Off"></span>
+                            <span class="font-weight-bold">Log Off</span>
+                        </button>
+                    </fieldset>
+                }
             </li>
             }
         </ul>


### PR DESCRIPTION
The changes here update the logoff action to a `HttpPost` instead of an
`HttpGet` which allows the usage of an antiforgery token to prevent any
CSRF attacks on logout.
