### PR TITLE
(GH-827) Fix JS on Install and Verify Package page

### DIFF
--- a/chocolatey/Website/Scripts/install-steps/install-steps.js
+++ b/chocolatey/Website/Scripts/install-steps/install-steps.js
@@ -1,0 +1,20 @@
+$(function () {
+    $("code:contains('STEP 3 URL')").html(function (_, html) {
+        $(this).parent().next().remove();
+        return html.replace(/(STEP 3 URL)/g, '<span class="stepThreeUrl">$1</span>');
+    });
+    $('[id*="stepThreeUrl"]').keyup(function () {
+        var value = $(this).val();
+        var defaultUrl = "http://internal/odata/repo";
+
+        $('.stepThreeUrl').text(value);
+        if (value == 0) {
+            $('.stepThreeUrl').text(defaultUrl);
+            $('.stepThree .tab-pane').prepend('<p class="step-three-danger text-danger font-weight-bold small">You must enter your internal repository url in Step 3 before proceeding.</p>');
+            $('#install-step4 .code-toolbar').prepend('<p class="step-three-danger text-danger font-weight-bold small">You must enter your internal repository url in Step 3 before proceeding.</p>');
+        }
+        else {
+            $('.step-three-danger').remove();
+        }
+    }).keyup();
+});

--- a/chocolatey/Website/Scripts/packages/package-details.js
+++ b/chocolatey/Website/Scripts/packages/package-details.js
@@ -98,26 +98,6 @@ $(function () {
             fileCollapse.collapse('hide');
         }
     });
-
-    // Installation Tabs
-    $("code:contains('STEP 3 URL')").html(function (_, html) {
-        $(this).parent().next().remove();
-        return html.replace(/(STEP 3 URL)/g, '<span class="stepThreeUrl">$1</span>');
-    });
-    $('[id*="stepThreeUrl"]').keyup(function () {
-        var value = $(this).val();
-        var defaultUrl = "http://internal/odata/repo";
-
-        $('.stepThreeUrl').text(value);
-        if (value == 0) {
-            $('.stepThreeUrl').text(defaultUrl);
-            $('.stepThree .tab-pane').prepend('<p class="step-three-danger text-danger font-weight-bold small">You must enter your internal repository url in Step 3 before proceeding.</p>');
-            $('#install-step4 .code-toolbar').prepend('<p class="step-three-danger text-danger font-weight-bold small">You must enter your internal repository url in Step 3 before proceeding.</p>');
-        }
-        else {
-            $('.step-three-danger').remove();
-        }
-    }).keyup();
     
     // Initialize Text Editor
     $('.text-editor').each(function () {

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -13,6 +13,7 @@
     Bundles.Reference("Scripts");
     Bundles.Reference("Scripts/packages");
     Bundles.Reference("Scripts/prism");
+    Bundles.Reference("Scripts/install-steps");
     Bundles.Reference("Scripts/easymde");
     Bundles.Reference("Scripts/closeable");
 

--- a/chocolatey/Website/Views/Packages/VerifyPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/VerifyPackage.cshtml
@@ -8,7 +8,6 @@
     Bundles.Reference("Content/account.css");
     Bundles.Reference("Content/prism/prism.css");
     Bundles.Reference("Scripts");
-    Bundles.Reference("Scripts/packages");
     Bundles.Reference("Scripts/prism");
 
     var markdownPipelineBuilder = new MarkdownPipelineBuilder()

--- a/chocolatey/Website/Views/Pages/Install.cshtml
+++ b/chocolatey/Website/Views/Pages/Install.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    Layout = "~/Views/Shared/NewsletterLayout.cshtml";
+    Layout = "~/Views/Shared/MainLayout.cshtml";
     ViewBag.Title = "Installing Chocolatey";
     Bundles.Reference("Content/dist/chocolatey.slim.css");
     Bundles.Reference("Content/prism/prism.css");

--- a/chocolatey/Website/Views/Pages/Install.cshtml
+++ b/chocolatey/Website/Views/Pages/Install.cshtml
@@ -4,8 +4,8 @@
     Bundles.Reference("Content/dist/chocolatey.slim.css");
     Bundles.Reference("Content/prism/prism.css");
     Bundles.Reference("Scripts");
-    Bundles.Reference("Scripts/packages");
     Bundles.Reference("Scripts/prism");
+    Bundles.Reference("Scripts/install-steps");
 }
 @Html.Partial("~/Views/Shared/_Loader.cshtml")
 <section class="py-3 py-md-5 container">

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1409,6 +1409,7 @@
     <Content Include="Scripts\header\bundle.txt" />
     <Content Include="Scripts\header\modernizr-2.6.2.js" />
     <Content Include="Scripts\home\bundle.txt" />
+    <Content Include="Scripts\install-steps\install-steps.js" />
     <Content Include="Scripts\jquery-3.3.1.js" />
     <Content Include="Scripts\manageowners\bundle.txt" />
     <Content Include="Scripts\manageowners\knockout.3.5.0.js" />


### PR DESCRIPTION
Currently when going to the Install or Verify Package (step 2 when uploading a package) page, there is a JS error of `'querySelectorAll' of undefined`, which is being caused by a snippet of JS that is meant to be run specifically on the Package Display page.

This error is causing the install steps area not to work on the Install page, and the file that contains this code is actually not needed at all on the Verify Package page.

The JS snippet that controls the install steps has been moved to its own JS file, which allows the `package-details.js` to be removed entirely from the 2 pages that do not need it. This cuts down on the amount of unnecessary JS on these 2 pages. The `install-steps.js` file has been added to the Package Display page and the Install page as those are the 2 pages that require it at this time.

In result, the file that is causing the initial error has been removed and contained to the specific page that is needed on which is the Package Details page.