### PR TITLE
(GH-830) Allow package related forms to submit

### DIFF
--- a/chocolatey/Website/Views/Authentication/LogOn.cshtml
+++ b/chocolatey/Website/Views/Authentication/LogOn.cshtml
@@ -20,7 +20,7 @@
 <h3 class="text-center">Chocolatey Community Login</h3>
 <p class="text-center"><small>Don't have an account yet? <a href="@Url.Action(MVC.Users.Register())">Register now.</a></small></p>
 <hr class="mb-0" />
-@using (Html.BeginForm())
+@using (Html.BeginForm("LogOn", "Authentication", FormMethod.Post, new { id = "i-recaptcha" }))
 {
     <fieldset class="form">
         <legend class="d-none">Log On Form</legend>
@@ -52,11 +52,6 @@
     </fieldset>
 }     
 @section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
     <script language="javascript" type="text/javascript">
         ((window.gitter = {}).chat = {}).options = {
             room: 'chocolatey/chocolatey.org'

--- a/chocolatey/Website/Views/Packages/ContactAdmins.cshtml
+++ b/chocolatey/Website/Views/Packages/ContactAdmins.cshtml
@@ -39,7 +39,7 @@
             <div class="callout callout-danger">
                 <p><strong>Do not share sensitive information with this form.</strong></p>
             </div>
-            @using (Html.BeginForm())
+            @using (Html.BeginForm("ContactAdmins", "Packages", FormMethod.Post, new { id = "i-recaptcha" }))
             {
                 <fieldset class="form">
                     <legend class="d-none">Contact Admins</legend>
@@ -79,11 +79,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Packages/ContactOwners.cshtml
+++ b/chocolatey/Website/Views/Packages/ContactOwners.cshtml
@@ -41,7 +41,7 @@
                 <div class="callout callout-danger">
                     <p><strong>Do not share sensitive information with this form.</strong></p>
                 </div>
-                using (Html.BeginForm())
+                using (Html.BeginForm("ContactOwners", "Packages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                     <fieldset class="form">
                         <legend class="d-none">Contact Maintainers</legend>
@@ -92,11 +92,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Packages/ReportAbuse.cshtml
+++ b/chocolatey/Website/Views/Packages/ReportAbuse.cshtml
@@ -39,7 +39,7 @@
             <div class="callout callout-danger">
                 <p><strong>Do not share sensitive information with this form.</strong></p>
             </div>
-            @using (Html.BeginForm())
+            @using (Html.BeginForm("ReportAbuse", "Packages", FormMethod.Post, new { id = "i-recaptcha" }))
             {
                 <fieldset class="form">
                     <legend class="d-none">Report Abuse</legend>
@@ -89,11 +89,6 @@
 </section>
 
 @section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
     <script language="javascript" type="text/javascript">
         ((window.gitter = {}).chat = {}).options = {
             room: 'chocolatey/chocolatey.org'

--- a/chocolatey/Website/Views/Pages/ContactBlocked.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactBlocked.cshtml
@@ -21,7 +21,7 @@
             <div class="col-xl-10 mx-auto">
                 <h2 class="text-primary">Blocked IP Address</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactBlocked", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                 <fieldset class="form">
                     <legend class="d-none">Blocked IP Address</legend>
@@ -87,11 +87,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactDiscount.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactDiscount.cshtml
@@ -23,7 +23,7 @@
             <div class="col-lg-8">
                 <h2 class="text-primary">Chocolatey Software Student Discount</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactDiscount", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                     <fieldset class="form">
                         <legend class="d-none">Discount Inquiry</legend>
@@ -82,11 +82,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactGeneral.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactGeneral.cshtml
@@ -25,7 +25,7 @@
                 <div class="callout callout-warning">
                     <strong>If you have found an issue or have questions</strong> (related to open source usage or package install issues), do not use this form! Please see <a href="@Url.RouteUrl(RouteName.Support)">Support</a> and <a href="@Url.RouteUrl(RouteName.ReportIssue)">Report Issue</a> for details.
                 </div>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactGeneral", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                 <fieldset class="form">
                     <legend class="d-none">Question or comments?</legend>
@@ -93,11 +93,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactPartner.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactPartner.cshtml
@@ -22,7 +22,7 @@
             <div class="col-lg-8">
                 <h2 class="text-primary">Partner with Chocolatey Software</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactPartner", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                     <fieldset class="form">
                         <legend class="d-none">Question or comments?</legend>
@@ -86,11 +86,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactSales.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactSales.cshtml
@@ -21,7 +21,7 @@
             <div class="col-lg-8">
                 <h2 class="text-primary">Contact Chocolatey Software Sales Team</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactSales", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                 <fieldset class="form">
                     <legend class="d-none">Sales Inquiry</legend>
@@ -90,11 +90,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactSalesOther.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactSalesOther.cshtml
@@ -22,7 +22,7 @@
             <div class="col-lg-8">
                 <h2 class="text-primary">Contact Chocolatey Software Sales Team</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactSalesOther", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                 <fieldset class="form">
                     <legend class="d-none">Sales Inquiry</legend>
@@ -91,11 +91,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/ContactTrial.cshtml
+++ b/chocolatey/Website/Views/Pages/ContactTrial.cshtml
@@ -22,7 +22,7 @@
             <div class="col-lg-8">
                 <h2 class="text-primary">Contact Us to Setup a Free Chocolatey for Business Trial</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("ContactTrial", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                     <fieldset class="form">
                         <legend class="d-none">Trial Inquiry</legend>
@@ -91,11 +91,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Pages/Discount.cshtml
+++ b/chocolatey/Website/Views/Pages/Discount.cshtml
@@ -22,7 +22,7 @@
             <div class="col-xl-6 mx-auto">
                 <h2 class="text-primary">Chocolatey Software Student Discount</h2>
                 <h4>Please provide the information below and we'll reach out as soon as possible.</h4>
-                @using (Html.BeginForm())
+                @using (Html.BeginForm("Discount", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))
                 {
                     <fieldset class="form">
                         <legend class="d-none">Student Discount</legend>
@@ -58,11 +58,3 @@
         </div>
     </div>
 </section>
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
-}

--- a/chocolatey/Website/Views/Users/Register.cshtml
+++ b/chocolatey/Website/Views/Users/Register.cshtml
@@ -18,7 +18,7 @@
 <h3 class="text-center">Create a New Account</h3>
 <p class="text-center"><small>Already have an account? <a href="@Url.LogOn()">Log On.</a></small></p>
 <hr class="mb-0" />
-@using (Html.BeginForm())
+@using (Html.BeginForm("Register", "Users", FormMethod.Post, new { id = "i-recaptcha" }))
 {
     <fieldset class="form">
         <legend class="d-none">Register Form</legend>
@@ -55,12 +55,4 @@
         <input class="btn btn-primary mx-auto mt-3 d-block g-recaptcha" data-sitekey="@System.Configuration.ConfigurationManager.AppSettings["reCAPTCHA::PublicKey"]" data-callback="onSubmit" data-badge="bottomleft" type="submit" value="Register" title="Register" />
         <p class="mb-0 mt-2 text-center"><small><a class="cancel" href="@Url.LogOn()" title="Cancel Changes and go back.">Cancel</a></small></p>
     </fieldset>
-}
-
-@section BottomScripts {
-    <script type="text/javascript">
-        $(document).ready(function () {
-            $('fieldset').parent().attr('id', 'i-recaptcha');
-        });
-    </script>
 }


### PR DESCRIPTION
Currently, the Contact Admins, Contact Owners, and Report Abuse forms do not submit, and instead trigger the LogOut action. This is due to the recaptcha JavaScript that is on these pages. JavaScript was previously being used on forms that needed recaptcha to add an ID element to the form, however this method does not work when there is more than one form on the page. The LogOff form for was mistakingly getting the recaptcha ID, which in tern was triggering another function to make the LogOff form submit (and logoff the user) whenever the intended form with recaptcha was submitted.

Instead of using JavaScript to identify forms that need the recaptcha ID, the ID has been added using razor syntax to the specified forms that need it. While only 3 forms need this at this time, the syntax has been changed site wide to keep consistency, and to prevent future problems.


Closes #830
