### PR TITLE
(GH-835, GH-838) Get username on authentication via ajax and prevent noscript flicker

### DIFF
--- a/chocolatey/Website/Controllers/PagesController.cs
+++ b/chocolatey/Website/Controllers/PagesController.cs
@@ -20,6 +20,7 @@ using System;
 using System.Linq;
 using System.Net.Mail;
 using System.Net.Mime;
+using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.Mvc;
@@ -32,11 +33,14 @@ namespace NuGetGallery
     {
         private readonly IAggregateStatsService statsSvc;
         private readonly IMessageService messageService;
+        private readonly IPrincipal currentUser;
 
-        public PagesController(IAggregateStatsService statsSvc, IMessageService messageService)
+        public PagesController(IAggregateStatsService statsSvc, IMessageService messageService, IPrincipal currentUser)
         {
             this.statsSvc = statsSvc;
             this.messageService = messageService;
+            this.currentUser = currentUser;
+
         }
 
         [HttpGet, OutputCache(CacheProfile = "Cache_2Hours")]
@@ -681,7 +685,17 @@ SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin";
         [ActionName("Home")]
         public virtual ActionResult IsAuthenticatedAjax()
         {
-            return Json(new { isAuthenticated = @Request.IsAuthenticated }, JsonRequestBehavior.AllowGet);
+            if (Request.IsAuthenticated)
+            {
+                return Json(
+                    new
+                    {
+                        isAuthenticated = true,
+                        userName = currentUser.Identity.Name
+                    }, JsonRequestBehavior.AllowGet);
+            }
+
+            return Json(new { isAuthenticated = false }, JsonRequestBehavior.AllowGet);
         }
     }
 }

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -476,10 +476,12 @@ $(function () {
 function authenticationSuccess(data, status) {
     var uxLogoff = $('.ux_logoff');
     var uxLogin = $('.ux_login');
+    var uxProfile = $('.ux_profile');
     $('.authentication-error').remove();
     if (data.isAuthenticated) {
         uxLogoff.removeClass('d-none');
         uxLogin.addClass('d-none');
+        uxProfile.find('a').prop('href', '/profiles/' + data.userName);
     } else {
         uxLogoff.addClass('d-none');
         uxLogin.removeClass('d-none');

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -1,5 +1,6 @@
 // Preloader
 $(window).on('load', function () {
+    $('.authentication-error').remove();
     $('#loader').fadeOut(500, function () {
         $(this).remove();
     });
@@ -477,7 +478,6 @@ function authenticationSuccess(data, status) {
     var uxLogoff = $('.ux_logoff');
     var uxLogin = $('.ux_login');
     var uxProfile = $('.ux_profile');
-    $('.authentication-error').remove();
     if (data.isAuthenticated) {
         uxLogoff.removeClass('d-none');
         uxLogin.addClass('d-none');

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -118,7 +118,6 @@
 {
     @Html.Partial("~/Views/Packages/_CommunityInfoDisclaimer.cshtml")
 }
-@Html.Partial("~/Views/Shared/_Loader.cshtml")
 <section id="secondaryNav">
     @Html.Partial("~/Views/Shared/_AuthenticationSubNavigation.cshtml")
     @Html.Partial("~/Views/Shared/_PackageStatusSubNavigation.cshtml")

--- a/chocolatey/Website/Views/Packages/ListPackages.cshtml
+++ b/chocolatey/Website/Views/Packages/ListPackages.cshtml
@@ -19,7 +19,6 @@
     var packageWarning = Request.Cookies["chocolatey_hide_packages_warning"] == null;
 }
 
-@Html.Partial("~/Views/Shared/_Loader.cshtml")
 <section id="secondaryNav">
     <div class="bg-primary">
         <div class="container py-2">

--- a/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
@@ -1,4 +1,5 @@
-﻿<nav class="navbar bg-white border-bottom d-flex">
+﻿@Html.Partial("~/Views/Shared/_Loader.cshtml")
+<nav class="navbar bg-white border-bottom d-flex">
     <div class="container">
         <div class="authentication-error mx-auto text-danger">
             <p class="mb-0">Please enable JavaScript to view this sub navigation.</p>

--- a/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_AuthenticationSubNavigation.cshtml
@@ -35,7 +35,7 @@
                     <span>Account</span>
                 </a>
             </li>
-            <li>
+            <li class="ux_profile">
                 <a href="@Url.Action(MVC.Users.Profiles(User.Identity.Name))">
                     <span class="fas fa-user-alt" alt="Profile"></span>
                     <span>Profile</span>


### PR DESCRIPTION
The first page of the package area `/packages` is heavily cached. For this reason, we need to get the username via ajax call in order for the `profiles` link in the sub navigation to work. Now that we have the username, JavaScript can inject it on load, so that the link will work even if the page is heavily cached.

Method of retrieving the username in `PagesController.cs` is similar to how it is implemented in `UsersController.cs`.

This PR also prevents the flashing of the `noscript` text on load in the authentication sub navigation.

Fixes #835
Fixes #838 