### PR TITLE
Remove Top Alert Only on "X" Click and Maintenance

### DIFF
--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -33,10 +33,10 @@ if (!getCookie('chocolatey_hide_cookies_notice')) {
 $(document).ready(function () {
     // Top Alert
     var notice = window.sessionStorage.getItem('notice');
-    if (notice) {
-        $(".notice-text").addClass("d-none");
+    if (!notice && !$(".notice-text").hasClass('d-none')) {
+        $('.notice-text').show();
     }
-    $('.notice-text').click(function () {
+    $('.notice-text button').click(function () {
         sessionStorage.setItem('notice', 'true');
     });
     // Dropdowns on desktop

--- a/chocolatey/Website/Views/Pages/_SelfServiceResources.cshtml
+++ b/chocolatey/Website/Views/Pages/_SelfServiceResources.cshtml
@@ -18,7 +18,7 @@
                     <img class="img-fluid" src="@Url.Content("~/content/images/videos/04-02.jpg")" alt="Self-Service and Chocolatey GUI Intro" title="Self-Service and Chocolatey GUI Intro" />
                 </div>
                 <div class="card-footer">
-                    <h5 class="mb-0 text-center">Chocolatey for Business Self-Service and Chocoaltey GUI Intro</h5>
+                    <h5 class="mb-0 text-center">Chocolatey for Business Self-Service and Chocolatey GUI Intro</h5>
                 </div>
             </div>
         </a>
@@ -30,7 +30,7 @@
                     <img class="img-fluid" src="@Url.Content("~/content/images/videos/04-01.jpg")" alt="Self-Service and Chocolatey GUI Demo" title="Self-Service and Chocolatey GUI Demo" />
                 </div>
                 <div class="card-footer">
-                    <h5 class="mb-0 text-center">Chocolatey for Business Self-Service and Chocoaltey GUI Demo</h5>
+                    <h5 class="mb-0 text-center">Chocolatey for Business Self-Service and Chocolatey GUI Demo</h5>
                 </div>
             </div>
         </a>

--- a/chocolatey/Website/Views/Resources/Files/04-02-C4BSelfServiceAndChocolateyGuiIntro.md
+++ b/chocolatey/Website/Views/Resources/Files/04-02-C4BSelfServiceAndChocolateyGuiIntro.md
@@ -10,3 +10,4 @@ Tags: 2020,tutorial,c4b,chocolatey-for-business,self-service
 Image: <img class="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-src="/content/images/videos/04-02.jpg" alt="Chocolatey for Business Self-Service and Chocolatey GUI Intro" title="Chocolatey for Business Self-Service and Chocolatey GUI Intro" />
 Summary: Chocolatey for Business Self-Service and Chocolatey GUI Part 1: Intro
 ---
+<h5 class="text-center"><a href="/resources/videos/chocolatey-for-business-self-service-and-chocolatey-gui-demo">Click here</a> to view Part 2 of this video series and see a demo of <a href="/resources/videos/chocolatey-for-business-self-service-and-chocolatey-gui-demo">Chocolatey for Business Self-Service and Chocolatey GUI</a>.</h5>

--- a/chocolatey/Website/Views/Shared/_AlertTop.cshtml
+++ b/chocolatey/Website/Views/Shared/_AlertTop.cshtml
@@ -2,7 +2,7 @@
     var noticeText = ("<a href='/covid-19'><u>Here's how we're responding to COVID-19 plus resources to help</u></a>");
 }
 
-<div class="alert bg-danger text-white alert-dismissible fade show mb-0 text-center p-2 notice-text @if (string.IsNullOrEmpty(noticeText)) { <text> d-none</text> }" role="alert" aria-atomic="true">
+<div class="alert bg-danger text-white alert-dismissible fade show mb-0 text-center p-2 notice-text @if (string.IsNullOrEmpty(noticeText)) { <text> d-none</text> }" role="alert" aria-atomic="true" style="display: none;">
     <p class="mb-0 mr-3 mr-md-0"><strong>@Html.Raw(noticeText)</strong></p>
     <button type="button" class="close py-0" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
Currently, the top alert banner will be removed once a user clicks on
it by using a session storage item. Now, the top alert banner will stay
in place unless the user specifically clicks on the "X" in the right
corner to remove it.

Minor updates to the JS snippet controlling this feature was made. The
changes also eliminates the flash of red sometimes seen on page load if
a user has removed the alert.

Also includes:
* Typo fix
* Adds suggested video from Part 1 video