### PR TITLE
(layout) Adjust CSS on Profile Page

### DIFF
--- a/chocolatey/Website/Content/scss/_base.scss
+++ b/chocolatey/Website/Content/scss/_base.scss
@@ -365,14 +365,6 @@ footer {
     }
 }
 
-@include media-breakpoint-up(md) {
-    .divider-list li:not(:last-child) {
-        border-right: 1px solid #ced4da;
-        border-bottom: 0;
-        display: inline-block;
-    }
-}
-
 @include media-breakpoint-up(lg) {
     .copyBox {
         max-width: 550px;

--- a/chocolatey/Website/Content/scss/_lists.scss
+++ b/chocolatey/Website/Content/scss/_lists.scss
@@ -136,3 +136,11 @@
         }
     }
 }
+
+@include media-breakpoint-up(md) {
+    .divider-list li:not(:last-child) {
+        border-right: 1px solid #ced4da;
+        border-bottom: 0;
+        display: inline-block;
+    }
+}


### PR DESCRIPTION
Due to recent changes, the CSS that controls custom list styling has
been been moved to it's own scss file. The small snippet from
`_base.css` was missed during this transition and is now causing a
styling error on the profile page.

The snippet has been moved to the appropriate file which makes the
profile page appear how it should.