### PR TITLE
(docs) Add Markdig Emoji Extension to Docs

### DIFF
--- a/chocolatey/Website/Controllers/DocumentationController.cs
+++ b/chocolatey/Website/Controllers/DocumentationController.cs
@@ -50,6 +50,7 @@ namespace NuGetGallery.Controllers
                  .UseNoFollowLinks()
                  .UseCustomContainers()
                  .UseBootstrap()
+                 .UseEmojiAndSmiley()
                  .Build();
         }
 


### PR DESCRIPTION
With the addition of this extension, and emojis that might be used in
the documentation area in markdown will be converted to the appropriate
icon.

More info about this added extension at:
https://github.com/lunet-io/markdig/blob/master/src/Markdig.Tests/Specs/EmojiSpecs.md