### PR TITLE
(layout) Add Styling for Blockquotes

### DIFF
--- a/chocolatey/Website/Content/scss/_callouts.scss
+++ b/chocolatey/Website/Content/scss/_callouts.scss
@@ -1,20 +1,25 @@
 /*Callouts*/
-[class*="callout-"] {
+[class*="callout-"], blockquote {
     padding: 1rem;
     margin-bottom: 1rem;
     background: $white;
     box-shadow: $box-shadow-sm;
     position: relative;
     border-left: 6px solid;
+    font-size: $font-size-base !important;
 }
 
-[class*="callout-"]:not(.callout) {
+[class*="callout-"]:not(.callout):not(blockquote) {
     padding: .5rem 1rem;
     box-shadow: none;
 }
 
-[class*="callout-"] p:last-child {
+[class*="callout-"] p:last-child, blockquote p:last-child {
     margin-bottom: 0;
+}
+
+.callout-secondary, blockquote {
+    border-color: $secondary;
 }
 
 .callout-warning {
@@ -27,10 +32,6 @@
 
 .callout-primary {
     border-color: $primary;
-}
-
-.callout-secondary {
-    border-color: $secondary;
 }
 
 .callout-success {

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -678,3 +678,13 @@ $.each($('.video-overlay'), function () {
         }
     });
 });
+
+// Style blockquotes in markdown based on content
+$.each($('blockquote'), function () {
+    var warningEmoji = String.fromCodePoint(0x26A0);
+
+    if ($(this).text().indexOf(warningEmoji) >= 0) {
+        // Contains warning emoji
+        $(this).addClass('callout-warning');
+    }
+});


### PR DESCRIPTION
Adds styling for blockquote elements to resemble the usage of "callouts"
throughout the website. This will mostly be used when converting files
from markdown, otherwise the standard "callout" syntax should be used.