### PR TITLE
(maint) Update Links to Product Pages

### DIFF
--- a/chocolatey/Website/Views/Pages/Sitemap.cshtml
+++ b/chocolatey/Website/Views/Pages/Sitemap.cshtml
@@ -45,8 +45,8 @@
                             <li><a href="@Url.RouteUrl(RouteName.Solutions, new {solutionName = "home"})">Solution: Self-Service Anywhere</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-environment" })">Solution: Quick Deployment Environment (QDE)</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "chocolatey-for-business"})">Chocolatey for Business</a></li>
-                            <li><a href="@Url.RouteUrl(RouteName.Products)#pro-edition">Pro Edition</a></li>
-                            <li><a href="@Url.RouteUrl(RouteName.Products)#foss">Open Source</a></li>
+                            <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})#pro-edition">Pro Edition</a></li>
+                            <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"}))#foss">Open Source</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Compare)">Compare Editions</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Pricing)">Pricing</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.ContactUs)">Try for Free</a></li>

--- a/chocolatey/Website/Views/Pages/WhyChocolatey.cshtml
+++ b/chocolatey/Website/Views/Pages/WhyChocolatey.cshtml
@@ -145,7 +145,7 @@
                         <h3 class="text-center mb-0 w-75 mx-auto">I'm looking for solutions for my business</h3>
                     </div>
                     <div class="card-footer bg-white pt-0 pb-4">
-                        <a href="@Url.RouteUrl(RouteName.Products)" class="btn btn-primary">See Chocolatey Products</a>
+                        <a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})" class="btn btn-primary">See Chocolatey Products</a>
                     </div>
                 </div>
             </div>

--- a/chocolatey/Website/Views/Shared/_BottomNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_BottomNavigation.cshtml
@@ -21,8 +21,8 @@
                 <li><a href="@Url.RouteUrl(RouteName.Solutions, new {solutionName = "home"})">Solution: Self-Service Anywhere</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-environment" })">Solution: Quick Deployment Environment (QDE)</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "chocolatey-for-business"})">Chocolatey for Business</a></li>
-                <li><a href="@Url.RouteUrl(RouteName.Products)#pro-edition">Pro Edition</a></li>
-                <li><a href="@Url.RouteUrl(RouteName.Products)#foss">Open Source</a></li>
+                <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})#pro-edition">Pro Edition</a></li>
+                <li><a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})#foss">Open Source</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.ContactTrial)">C4B Trial</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Pricing)">Pricing</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Support)">Support</a></li>

--- a/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
@@ -78,11 +78,11 @@
                                             <p class="d-none d-md-block">Chocolatey for Business (C4B) is the enterprise offering that enables companies to adopt a DevOps approach to managing their Windows environment, allowing you to deliver applications to your users more reliably and faster.</p>
                                         </li>
                                         <li>
-                                            <a href="@Url.RouteUrl(RouteName.Products)#pro-edition">Pro Edition</a>
+                                            <a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})#pro-edition">Pro Edition</a>
                                             <p class="d-none d-md-block">Pro is a personal, named license that grants having licensed versions of Chocolatey on up to 8 machines and provides the ultimate Chocolatey experience!</p>
                                         </li>
                                         <li>
-                                            <a href="@Url.RouteUrl(RouteName.Products)#foss">Open Source</a>
+                                            <a href="@Url.RouteUrl(RouteName.Products, new {productName = "home"})#foss">Open Source</a>
                                             <p class="d-none d-md-block">Chocolatey has the largest online registry of Windows packages. Learn how Open Source Chocolatey can support your next project.</p>
                                         </li>
                                     </ul>


### PR DESCRIPTION
A recent change updated the routes to the Products page to include
another sub page products/chocolatey-for-business where in the URL
`productName` points the the page that should be displayed.

In order to show the main url of /products, `productName` should be
equal to "home" because that is the top level page. The url's to the
main /products page have been updated throughout the website.