### PR TITLE
(layout) Link to COVID-19 Resources

### DIFF
--- a/chocolatey/Website/Views/Pages/Sitemap.cshtml
+++ b/chocolatey/Website/Views/Pages/Sitemap.cshtml
@@ -62,6 +62,7 @@
                         <ul>
                             <li><a href="@Url.RouteUrl(RouteName.Courses)">Getting Started</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "home"})">Resource Library</a></li>
+                            <li><a href="@Url.RouteUrl(RouteName.Covid19)">COVID-19 Resources</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Docs, new {docName = "home"})">Docs</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "videos"})">Videos</a></li>
                             <li><a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "case-studies"})">Case Studies</a></li>

--- a/chocolatey/Website/Views/Resources/Home.cshtml
+++ b/chocolatey/Website/Views/Resources/Home.cshtml
@@ -134,7 +134,10 @@
     <div class="shape-border shape-border-top shape-border-light"></div>
     <section class="py-3 py-lg-5">
         <div class="container">
-            <h1 class="mb-5 text-center"><strong>Helpful Resources</strong></h1>
+            <h1 class="mb-5 text-center"><strong>COVID-19 Resources</strong></h1>
+            @Html.Partial("~/Views/Pages/_SelfServiceResources.cshtml")
+            @*TODO: Put this section back when timing is more relevent and remove COVID-19 resources*@
+            @*<h1 class="mb-5 text-center"><strong>Helpful Resources</strong></h1>
             <div class="row resource-list resource-d-3">
                 @foreach (var post in @Model)
                 {
@@ -214,7 +217,7 @@
                 <div class="col-12">
                     <a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "videos"})" class="btn btn-light">See More Videos</a>
                 </div>
-            </div>
+            </div>*@
         </div>
     </section>
     <div class="shape-border shape-border-bottom"></div>

--- a/chocolatey/Website/Views/Shared/_BottomNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_BottomNavigation.cshtml
@@ -34,6 +34,7 @@
             <h3>Learn</h3>
             <ul class="list-unstyled mb-0">
                 <li><a href="@Url.RouteUrl(RouteName.Resources)">Resource Library</a></li>
+                <li><a href="@Url.RouteUrl(RouteName.Covid19)">COVID-19 Resources</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "home" })">Docs</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "videos"})">Videos</a></li>
                 <li><a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "case-studies"})">Case Studies</a></li>

--- a/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
@@ -202,6 +202,10 @@
                                 <div class="col-md-4">
                                     <ul>
                                         <li>
+                                            <a href="@Url.RouteUrl(RouteName.Covid19)">COVID-19 Resources</a>
+                                            <p class="d-none d-md-block">Chocolatey Software is working harder than ever to provide solutions and resources for our customers and community. We'll continue to add to this area so check back often.</p>
+                                        </li>
+                                        <li>
                                             <a href="@Url.RouteUrl(RouteName.Support)">Support</a>
                                             <p class="d-none d-md-block">Need help? Read our Support FAQ to find out the next steps.</p>
                                         </li>


### PR DESCRIPTION
Adds the COVID-19 Resources to the main resource area page. In
addition, a link to the COVID-19 Page has been added under "Learn" in
the top nav, footer, and sitemap.