### PR TITLE
(maint) Update Timers on Event Pages

### DIFF
--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -697,7 +697,7 @@ $(function () {
     var ellapsedButtonText = 'Watch On-Demand Now';
 
     $('.countdown-container').each(function () {
-        $(this).countdown(countdownDate + ' ' + countdownHour + ':' + countdownMinutes + ':00', function (event) {
+        $(this).countdown(countdownDate + ' ' + countdownHour + ':' + countdownMinutes + ':00 UTC', function (event) {
             if (event.elapsed) {
                 $('.countdown-details').add($('.countdown-container').add($('.countdown-date'))).remove();
                 $('#countdown-header section').removeClass('pb-5').addClass('pb-0');

--- a/chocolatey/Website/Views/Events/Files/01-00-ExampleEvent.md
+++ b/chocolatey/Website/Views/Events/Files/01-00-ExampleEvent.md
@@ -1,7 +1,7 @@
 IsArchived: true
 Url: example-event
 Type: webinar
-EventDate: 20250101T10:00:00
+EventDate: 20250101T15:00:00
 Time: 10-11 AM CDT (8-9 AM PDT / 3-4 PM GMT)
 Duration: 1 hour
 Title: Example Event

--- a/chocolatey/Website/Views/Events/Files/01-01-EnableYourRemoteWorkforceByImplementingModernInfrastructureWithChocolatey.md
+++ b/chocolatey/Website/Views/Events/Files/01-01-EnableYourRemoteWorkforceByImplementingModernInfrastructureWithChocolatey.md
@@ -1,7 +1,7 @@
 IsArchived: false
 Url: enable-your-remote-workforce-by-implementing-modern-infrastructure-with-chocolatey
 Type: webinar
-EventDate: 20200604T10:00:00
+EventDate: 20200604T15:00:00
 Time: 10-11 AM CDT (8-9 AM PDT / 3-4 PM GMT)
 Duration: 1 hour
 Title: Enable Your Remote Workforce by Implementing Modern Infrastructure with Chocolatey

--- a/chocolatey/Website/Views/Events/Files/01-02-ChocolateyDeployments.md
+++ b/chocolatey/Website/Views/Events/Files/01-02-ChocolateyDeployments.md
@@ -1,7 +1,7 @@
 IsArchived: false
 Url: chocolatey-deployments
 Type: webinar
-EventDate: 20200623T10:00:00
+EventDate: 20200623T15:00:00
 Time: 10-11 AM CDT (8-9 AM PDT / 3-4 PM GMT)
 Duration: 1 hour
 Title: Chocolatey Deployments - Easily Orchestrate Amazing Things!

--- a/chocolatey/Website/Views/Events/Home.cshtml
+++ b/chocolatey/Website/Views/Events/Home.cshtml
@@ -24,12 +24,12 @@
 </div>
 <section id="events" class="pb-3 pb-lg-5">
     <div class="container">
-        @if (Model.Any(x => x.EventDate > DateTime.Now))
+        @if (Model.Any(x => x.EventDate > DateTime.UtcNow))
         {
             <h2>Upcoming Events</h2>
             <hr />
             <ul class="list-unstyled">
-                @foreach (var post in @Model.Where(x => x.EventDate > DateTime.Now))
+                @foreach (var post in @Model.Where(x => x.EventDate > DateTime.UtcNow))
                 {
                     var badgeClass = "";
                     switch (post.Type)
@@ -89,12 +89,12 @@
                 }
             </ul>
         }
-        @if (Model.Any(x => x.EventDate < DateTime.Now))
+        @if (Model.Any(x => x.EventDate < DateTime.UtcNow))
         {
-            <h2 class="@if(Model.Any(x => x.EventDate > DateTime.Now)){ <text>mt-5</text>}">On-Demand Events</h2>
+            <h2 class="@if(Model.Any(x => x.EventDate > DateTime.UtcNow)){ <text>mt-5</text>}">On-Demand Events</h2>
             <hr />
             <ul class="list-unstyled">
-                @foreach (var post in @Model.Where(x => x.EventDate < DateTime.Now))
+                @foreach (var post in @Model.Where(x => x.EventDate < DateTime.UtcNow))
                 {
                     var badgeClass = "";
                     switch (post.Type)

--- a/chocolatey/Website/Views/Events/README.md
+++ b/chocolatey/Website/Views/Events/README.md
@@ -82,7 +82,7 @@ Example `.cshmtl` file: `AwesomeConference.cshtml`
 | IsArchived        | true     | true or false								| false                             | If this field is set to `true`, then it will not appear in the list of events, and the event page will be redirected back to the main events area. |
 | URL               | true     | string											| example-event	                    | This will be the title of the event, all lowercase, with dashes in between each word. |
 | Type              | true     | webinar, workshop, conference					| webinar                           | |
-| EventDate         | true     | yyyyMMddTHH:mm:ss								| 20250101T10:00:00                 | This date is primarily used to configure the countdown clock via JS. This is done automatically. |
+| EventDate         | true     | yyyyMMddTHH:mm:ss								| 20250101T15:00:00                 | This date is primarily used to configure the countdown clock via JS, and to move items on the main event page from "upcoming" to "on-demand". The format uses a 24-hour clock from 0 to 23 and should be set to UTC. |
 | Time              | true     | string											| 10-11 AM CDT (8-9 AM PDT / 3-4 PM GMT) | This is the user friendly time of the event. This format can be whatever makes sense for the event. |
 | Duration          | true     | string											| 1 hour | The estimated length of event. |
 | Title             | true     | string with every word capitalized				| Example Event                     | |


### PR DESCRIPTION
The countdown timers on the event pages were off due to not being
converted to the correct timezone. Now, the `EventDate` is set to UTC
across the board to ensure consistency. This field is only used to set
the countdown clocks on the individual event, and to move items on the
main event page from "upcoming" to the "on-demand" sections.