### PR TITLE
(maint) Correct typo on upload package page

### DIFF
--- a/chocolatey/Website/Views/Packages/UploadPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/UploadPackage.cshtml
@@ -13,7 +13,7 @@
 </section>
 <section id="account" class="container upload-package py-3 py-md-5">
     <div class="callout-warning">
-        <strong>Warning:</strong> Directly uploading nupkg files through the Chocolatey Community Repository Website is not longer supported.  All packages should be uploaded using the choco push command.  See <a href="@Url.Action(MVC.Users.Account())">account</a> for details on associating your API key with your local Chocolatey install.
+        <strong>Warning:</strong> Directly uploading nupkg files through the Chocolatey Community Repository Website is no longer supported.  All packages should be uploaded using the choco push command.  See <a href="@Url.Action(MVC.Users.Account())">account</a> for details on associating your API key with your local Chocolatey install.
     </div>
     <h3 class="mt-4">Example Usage:</h3>
     <pre class="py-2 mb-0 border line-numbers language-powershell"><code class="language-powershell">choco push MyPackage.1.0.nupkg --source https://push.chocolatey.org/</code></pre>


### PR DESCRIPTION
There was is a small typo on the deprecated upload package page, this PR corrects that typo.