### PR TITLE
(layout) Update Home Page Announcement

### DIFF
--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -69,11 +69,6 @@
                 <h4 class="mb-0">WEBINAR</h4>
                 <h1 class="font-weight-bold display-4 d-none d-sm-block">Chocolatey Deployments -<br />Easily Orchestrate Amazing Things!</h1>
                 <h2 class="font-weight-bold d-sm-none">Chocolatey Deployments -<br />Easily Orchestrate Amazing Things!</h2>
-                <h5>
-                    <span class="mr-md-4 mb-1 mb-md-0 d-inline-block"><i class="fas fa-calendar"></i> Tuesday, 23 June 2020</span>
-                    <br class="d-md-none" />
-                    <span><i class="fas fa-clock"></i> 10-11 AM CDT <br class="d-sm-none" />(8-9 AM PDT / 3-4 PM GMT)</span>
-                </h5>
             </div>
             <div class="row divider-row align-items-center my-4">
                 <div class="col-sm-6 mb-3 mb-sm-0">
@@ -103,7 +98,7 @@
                 Chocolatey Central Management now includes the premiere feature of managing endpoints through a Chocolatey-centered solution aka Deployments. We are excited to share what Deployments is all about!
             </p>
             <div class="text-center">
-                <a href="https://chocolatey.zoom.us/webinar/register/WN_MPT5b34zQnud8R0nGgpe5A" target="_blank" rel="noreferrer" class="btn btn-success btn-lg mb-2"><span class="h2 font-weight-bold">Reserve My Spot Now</span></a>
+                <a href="https://chocolatey.zoom.us/webinar/register/WN_MPT5b34zQnud8R0nGgpe5A" target="_blank" rel="noreferrer" class="btn btn-success btn-lg mb-2"><span class="h2 font-weight-bold">Watch On-Demand Now</span></a>
                 <p class="mb-0"><a href="@Url.RouteUrl(RouteName.BlogArticle, new { articleName = "announcing-deployments" })">Read The Blog</a> | <a href="@Url.RouteUrl(RouteName.Events, new { eventName = "chocolatey-deployments" })">Learn More<span class="fas fa-angle-right"></span></a></p>
             </div>
         </div>


### PR DESCRIPTION
Note: This is to be merged after the Deployments Webinar has ended.

Updates the webinar announcement on the home page to "Watch On-Demand"
instead of "Reserve My Spot", as the webinar is now over and the replay
is available.