### PR TITLE
(GH-922) Show Content Inside Collapsed Text Editor

### DIFF
--- a/chocolatey/Website/Scripts/packages/package-details.js
+++ b/chocolatey/Website/Scripts/packages/package-details.js
@@ -101,13 +101,14 @@ $(function () {
     
     // Initialize Text Editor
     $('.text-editor').each(function () {
+        var placeholder = "";
+
         if ($(this).is('#NewReviewComments')) {
-            var placeholder = "Add to Review Comments";
+            placeholder = "Add to Review Comments";
         }
         else if ($(this).is('#ExemptedFromVerificationReason')) {
             placeholder = "Exempted Reason";
         }
-
         var easymde = new EasyMDE({
             element: this,
             autoDownloadFontAwesome: false,
@@ -116,7 +117,21 @@ $(function () {
         });
         easymde.render();
         $('<span> Preview</span>').insertAfter($(this).next().find('.fa-eye')).parent().addClass('font-weight-bold text-primary');
+        // Below snippet added to allow content to be shown inside of collapsed or hidden items without having to click on the textarea. See https://github.com/Ionaru/easy-markdown-editor/issues/208#issuecomment-645656131.
+        easymde.element.cmirror = easymde.codemirror;
     });
+    // Below snippet added to allow content to be shown inside of collapsed or hidden items without having to click on the textarea. See https://github.com/Ionaru/easy-markdown-editor/issues/208#issuecomment-645656131.
+    $('.text-editor-refresh').each(function () {
+        $(this).on('shown.bs.collapse', function () {
+            if (!$(this).hasClass('text-editor-refreshed')) {
+                var easymdeRefresh = $(this).attr('id');
+
+                $('#' + easymdeRefresh + ' textarea')[0].cmirror.refresh();
+                $('#' + easymdeRefresh).addClass('text-editor-refreshed');
+            }
+        });
+    });
+
     // Hide comment instructions
     $('#instructions').on('hidden.bs.collapse', function () {
         if (!getCookie('chocolatey_hide_comment_instructions')) {

--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -1152,7 +1152,7 @@ salt '*' chocolatey.install @Model.Id.ToLower() version="@Model.Version" source=
                                         }
                                     </div>
                                     <button class="btn btn-sm btn-secondary mt-2" type="button" data-toggle="collapse" data-target="#test-exemptions" aria-expanded="false" aria-controls="test-exemptions">Show Testing Exemption Section</button>
-                                    <div class="collapse form-field" id="test-exemptions">
+                                    <div class="collapse form-field text-editor-refresh" id="test-exemptions">
                                         <ul class="mb-0 mt-3">
                                             <li>Exempting a package id from testing requires a reason.</li>
                                             @if (moderator)


### PR DESCRIPTION
There is a slight bug in the Easymde JS library used that when a text
editor is hidden on load inside a collapsed or tabbed item, the content
is not displayed until the editor is clicked on. A fix has been
put in place that will basically "refresh" the editor whenever the
hidden editor becomes visible. A new class must be applied to the
collapsible item of "text-editor-refresh" in order for this JS to
trigger.

More information on this bug and fix here:
https://github.com/Ionaru/easy-markdown-editor/issues/208#issuecomment-645656131