### PR TITLE
Delete old instructions from package upload docs

### DIFF
--- a/chocolatey/Website/Views/Courses/CreatingChocolateyPackages/BuildingTestingAndPushing.cshtml
+++ b/chocolatey/Website/Views/Courses/CreatingChocolateyPackages/BuildingTestingAndPushing.cshtml
@@ -40,7 +40,6 @@
 
 <h2 id="pushing" class="mt-5 mb-3">Pushing Your Package</h2>
 <p>To push your package after you have built and tested it, you type <code>choco push packageName.nupkg -s sourceLocation</code> where <em>packageName.nupkg</em> is the name of the nupkg that was built with a version number as part of the package name and <em>sourceLocation</em> is the location of the source you want to push to (e.g. <code>https://push.chocolatey.org/</code> for chocolatey's community feed). You must have an api key for <a href="https://chocolatey.org/" class="uri">https://chocolatey.org/</a> set. Take a look at <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "commands-push" })">choco push</a></p>
-<p>You can also log into chocolatey.org and upload your package from there (not recommended for packages over 2MB).</p>
 
 @*Quiz*@
 <div>

--- a/chocolatey/Website/Views/Documentation/Files/CreatePackages.md
+++ b/chocolatey/Website/Views/Documentation/Files/CreatePackages.md
@@ -374,8 +374,6 @@ You can also type `choco install -fdv path/to/nuspec` and choco will build the n
 
 To push your package after you have built and tested it, you type `choco push packageName.nupkg -s sourceLocation` where *packageName.nupkg* is the name of the nupkg that was built with a version number as part of the package name and *sourceLocation* is the location of the source you want to push to (e.g. `-s https://chocolatey.org/` for chocolatey's community feed).  You must have an api key for https://chocolatey.org/ set. Take a look at [[choco push|CommandsPush]]
 
-You can also log into chocolatey.org and upload your package from there (not recommended for packages over 2MB).
-
 ## Automatic packaging?
 Yes - [[Automatic Packaging|AutomaticPackages]]
 

--- a/chocolatey/Website/Views/Documentation/Files/CreatePackages.md
+++ b/chocolatey/Website/Views/Documentation/Files/CreatePackages.md
@@ -374,6 +374,8 @@ You can also type `choco install -fdv path/to/nuspec` and choco will build the n
 
 To push your package after you have built and tested it, you type `choco push packageName.nupkg -s sourceLocation` where *packageName.nupkg* is the name of the nupkg that was built with a version number as part of the package name and *sourceLocation* is the location of the source you want to push to (e.g. `-s https://chocolatey.org/` for chocolatey's community feed).  You must have an api key for https://chocolatey.org/ set. Take a look at [[choco push|CommandsPush]]
 
+You can also log into chocolatey.org and upload your package from there (not recommended for packages over 2MB).
+
 ## Automatic packaging?
 Yes - [[Automatic Packaging|AutomaticPackages]]
 


### PR DESCRIPTION
Remove documentation references to manually uploading package to website, as this functionality has been disabled.