### PR TITLE
(layout) Add Right Side Announcement Bar

### DIFF
--- a/chocolatey/Website/Content/scss/_base.scss
+++ b/chocolatey/Website/Content/scss/_base.scss
@@ -64,6 +64,10 @@ code:not([class*="language-"]) {
     text-decoration: underline;
 }
 
+.btn-row > div:not(:last-child) {
+    margin-right: 1rem;
+}
+
 .btn-secondary {
     &.btn-twitter {
         background: #00aced;
@@ -449,5 +453,25 @@ footer {
 
     .divider-row [class*=col-] {
         padding: 0 2rem;
+    }
+}
+
+@media (min-width: 1660px) {
+    .d-xxxl-block {
+        display: block !important;
+    }
+
+    .col-xxxl-2 {
+        flex: 0 0 16.66667%;
+        max-width: 16.66667%;
+    }
+
+    .col-xxxl-8 {
+        flex: 0 0 66.66667% !important;
+        max-width: 66.66667% !important;
+    }
+
+    .pr-xxxl-5 {
+        padding-right: 3rem !important;
     }
 }

--- a/chocolatey/Website/Content/scss/_collapsing-sidebar.scss
+++ b/chocolatey/Website/Content/scss/_collapsing-sidebar.scss
@@ -1,0 +1,49 @@
+.btn-collapsing-right-sidebar {
+    position: fixed;
+    top: 40%;
+    right: 0;
+    border-radius: 50% 0 0 50%;
+    z-index: 9999;
+    width: auto !important;
+
+    &:before {
+        content: none !important;
+    }
+}
+
+#collapsing-right-sidebar {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    height: 100vh;
+    z-index: 99999;
+    background: #fff;
+    transition: none;
+    margin-left: 0;
+    overflow: auto;
+    border-left: 3px solid $primary;
+    padding-bottom: 150px;
+
+    a[data-toggle=collapse]:before {
+        content: none !important;
+    }
+}
+
+@include media-breakpoint-up(sm) {
+    .btn-collapsing-right-sidebar {
+        right: 350px;
+
+        &.collapsed {
+            right: 0;
+        }
+    }
+
+    #collapsing-right-sidebar {
+        position: fixed;
+        width: 350px;
+        left: auto;
+        padding-bottom: 1rem;
+    }
+}

--- a/chocolatey/Website/Content/scss/chocolatey.scss
+++ b/chocolatey/Website/Content/scss/chocolatey.scss
@@ -27,3 +27,4 @@
 @import "Content/scss/cards";
 @import "Content/scss/ribbons";
 @import "Content/scss/countdown";
+@import "Content/scss/collapsing-sidebar";

--- a/chocolatey/Website/Content/scss/purge.scss
+++ b/chocolatey/Website/Content/scss/purge.scss
@@ -45,3 +45,24 @@
     overflow: hidden;
     transition: height .35s ease;
 }
+
+/*Gitter*/
+.gitter-chat-embed {
+    right: 60%;
+    left: 0;
+    border-right: 3px solid #5c9fd8;
+
+    &:after {
+        left: 0;
+        right: 100%;
+    }
+
+    &.is-collapsed:not(.is-loading) {
+        transform: translateX(-110%);
+    }
+}
+
+.gitter-open-chat-button {
+    right: unset;
+    left: 10px;
+}

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -39,6 +39,7 @@ $(document).ready(function () {
     $('.notice-text button').click(function () {
         sessionStorage.setItem('notice', 'true');
     });
+
     // Dropdowns on desktop
     $(".dropdown").on("click.bs.dropdown", function (e) {
         $target = $(e.target);
@@ -61,13 +62,16 @@ $(document).ready(function () {
     });
     // Close the dropdown when page is scrolled
     $(window).on("scroll", function () {
-        if ($(this).width() > 992) {
+        if (window.innerWidth > 992) {
             closeDropdowns();
         }
     });
     // Close the dropdown when viewport is resized on desktop
     $(window).on("resize", function () {
-        if ($(this).width() > 992) {
+        if (window.innerWidth > 768) {
+            closeSidebar();
+        }
+        if (window.innerWidth > 992) {
             closeDropdowns();
             closeNav();
         }
@@ -76,17 +80,26 @@ $(document).ready(function () {
     $('.goback').click(function () {
         closeDropdowns();
     });
+
     // Add/Remove fixed positioning for mobile
-    $('#topNav').on('show.bs.collapse', function () {
-        if ($(window).width() < 768) {
-            $(this).parent().addClass("position-fixed").css("z-index", "999").css("top", "0");
-            $("body").addClass("position-fixed");
-        }
-    });
-    $('#topNav').on('hide.bs.collapse', function () {
-        $(this).parent().removeClass("position-fixed");
-        $("body").removeClass("position-fixed");
-    });
+    $('.collapsing-sidebar').add('#topNav')
+        .on('shown.bs.collapse', function () {
+            if (window.innerWidth < 768) {
+                $("body").addClass("position-fixed");
+
+                if (!$(this).hasClass('collapsing-sidebar')) {
+                    $(this).parent().addClass("position-fixed").css("z-index", "999").css("top", "0");
+                }
+            }
+        })
+        .on('hidden.bs.collapse', function () {
+            $("body").removeClass("position-fixed");
+
+            if (!$(this).hasClass('collapsing-sidebar')) {
+                $(this).parent().removeClass("position-fixed");
+            }
+        });
+
     // Closes Sub Nav
     function closeDropdowns() {
         $(".dropdown.show").find(".dropdown-toggle").dropdown('toggle');
@@ -94,6 +107,10 @@ $(document).ready(function () {
     // Closes Main Nav
     function closeNav() {
         $(".navbar-collapse.show").collapse('toggle');
+    }
+    // Closes Sidebar
+    function closeSidebar() {
+        $(".collapsing-sidebar.show").collapse('toggle');
     }
 });
 
@@ -403,7 +420,7 @@ $('.information-carousel')
         $(this).find(".video-story .modal").modal('hide');
     });
 $(window).on("scroll", function () {
-    if ($(this).width() > 1200) {
+    if (window.innerWidth > 1200) {
         $(".video-story .modal").modal('hide');
     }
 });
@@ -432,7 +449,7 @@ $(function () {
     });
 
     function tabs() {
-        if ($(window).width() < 576) {
+        if (window.innerWidth < 576) {
             $(".nav-tabs .nav-item").addClass("w-100");
             $(".nav-tabs .nav-link").addClass("btn btn-outline-primary").removeClass("nav-link");
         }
@@ -615,33 +632,21 @@ $('.nav-search .btn-search').click(function () {
         btnSearchOption.html('<span class="small"><i class="fas fa-search" alt="Search Packages"></i> Packages</span>');
         btnSearchOption.after('<button class="btn btn-light btn-docs" type="submit" formaction="/docs/search"><span class="small"><i class="fas fa-file" alt="Search Docs"></i> Docs</span></button>');
     }
-    navSearch();
-    searchHelpShow();
-
-    $(window).on("resize", function () {
-        navSearch();
-    });
-
-    function navSearch() {
-        if (btnSearch.hasClass('d-none')) {
-            if ($(window).width() < 576) {
-                $('#topNav').find('.navbar-brand').addClass('d-none').next().addClass('w-100').find('.nav-search').addClass('w-100');
-                $('#topNav').find('.btn-nav-toggle').addClass('d-none');
-            }
-            else {
-                $('#topNav').find('.navbar-brand').removeClass('d-none').next().removeClass('w-100').find('.nav-search').removeClass('w-100');
-                $('#topNav').find('.btn-nav-toggle').removeClass('d-none');
-            }
-        }
+    if (window.innerWidth < 625) {
+        $('#topNav').find('.navbar-brand').addClass('d-none').next().addClass('w-100').find('.nav-search').addClass('w-100');
+        $('#topNav').find('.btn-nav-toggle').parent().addClass('d-none');
+        $('#topNav').find('.btn-announcements').parent().addClass('d-none');
     }
+    searchHelpShow();
 });
-$(window).on("resize, click", function () {
+$(window).on("resize click", function () {
     if ($('.nav-search .btn-search').hasClass('d-none')) {
         $('.nav-search form').addClass('d-none').next().removeClass('d-none');
 
-        if ($(window).width() < 576) {
+        if (window.innerWidth < 625) {
             $('#topNav').find('.navbar-brand').removeClass('d-none').next().removeClass('w-100').find('.nav-search').removeClass('w-100');
-            $('#topNav').find('.btn-nav-toggle').removeClass('d-none');
+            $('#topNav').find('.btn-nav-toggle').parent().removeClass('d-none');
+            $('#topNav').find('.btn-announcements').parent().removeClass('d-none');
         }
     }
     searchHelpHide();

--- a/chocolatey/Website/Views/Packages/ListPackages.cshtml
+++ b/chocolatey/Website/Views/Packages/ListPackages.cshtml
@@ -32,237 +32,245 @@
     @Html.Partial("~/Views/Shared/_AuthenticationSubNavigation.cshtml")
     @Html.Partial("~/Views/Shared/_PackageStatusSubNavigation.cshtml")
 </section>
-<section id="package" class="container py-3 py-lg-5 body-tabs">
-    @if (!User.Identity.IsAuthenticated)
-    {
-        <div id="callout-package-warning" class="callout callout-warning py-2">
-            <div class="d-md-flex justify-content-md-between align-items-md-center">
-                <h5 class="mb-0 font-weight-bold"><span class="fas fa-exclamation-triangle text-warning"></span> Community Package Repository Notification</h5>
-                <div class="mt-2 mt-md-0">
-                    <a class="@if(packageWarning){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#package-warning" role="button" aria-expanded="true" aria-controls="package-warning" title="Package Warning">
-                        @if(packageWarning){<text>Hide</text>}else{<text>Show</text>} Notification
-                    </a>
+<section id="package" class="container-fluid body-tabs">
+    <div class="row">
+        <div class="d-none d-xxxl-block col-xxxl-2"></div>
+        <div class="col-md-8 col-xl-9 col-xxxl-8 py-3 py-xl-5 pr-xxxl-5">
+            @if (!User.Identity.IsAuthenticated)
+            {
+                <div id="callout-package-warning" class="callout callout-warning py-2">
+                    <div class="d-md-flex justify-content-md-between align-items-md-center">
+                        <h5 class="mb-0 font-weight-bold"><span class="fas fa-exclamation-triangle text-warning"></span> Community Package Repository Notification</h5>
+                        <div class="mt-2 mt-md-0">
+                            <a class="@if(packageWarning){<text>collapse show</text>}else{<text>collapsed</text>} btn btn-sm btn-secondary" data-toggle="collapse" href="#package-warning" role="button" aria-expanded="true" aria-controls="package-warning" title="Package Warning">
+                                @if(packageWarning){<text>Hide</text>}else{<text>Show</text>} Notification
+                            </a>
+                        </div>
+                    </div>
+                    <div class="collapse mt-2 @if(packageWarning){<text>show</text>}" id="package-warning">
+                        <p>Your use of the packages on this site means you understand they are not supported or guaranteed in any way. Due to the nature of a public repository and unreliability due to distribution rights, these packages should not be used as is for organizational purposes either. <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "community-packages-disclaimer" })">Learn more</a>.</p>
+                    </div>
                 </div>
-            </div>
-            <div class="collapse mt-2 @if(packageWarning){<text>show</text>}" id="package-warning">
-                <p>Your use of the packages on this site means you understand they are not supported or guaranteed in any way. Due to the nature of a public repository and unreliability due to distribution rights, these packages should not be used as is for organizational purposes either. <a href="@Url.RouteUrl(RouteName.Docs, new { docName = "community-packages-disclaimer" })">Learn more</a>.</p>
-            </div>
-        </div>
-        @Html.Partial("~/Views/Packages/_CommunityInfoDisclaimer.cshtml")
-    }
-    @if (!String.IsNullOrEmpty(Model.SearchTerm))
-    {
-        <ul class="nav nav-tabs mb-3" role="tablist">
-            <li class="nav-item">
-                <a class="nav-link active" id="packages-tab" data-toggle="tab" href="#packages-results" role="tab" aria-controls="packages-results" aria-selected="true">View Packages</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" id="documentation-tab" data-toggle="tab" href="#documentation-results" role="tab" aria-controls="documentation-results" aria-selected="false">View Documentation</a>
-            </li>
-        </ul>
-    }
-    <div class="tab-content">
-        <div class="tab-pane fade show active" id="packages-results" role="tabpanel" aria-labelledby="packages-tab">
-            <div class="d-lg-flex align-items-lg-center justify-content-lg-between">
-                <div>
-                    @if (!String.IsNullOrEmpty(Model.SearchTerm) && !moderationQueue)
+                @Html.Partial("~/Views/Packages/_CommunityInfoDisclaimer.cshtml")
+            }
+            @if (!String.IsNullOrEmpty(Model.SearchTerm))
+            {
+                <ul class="nav nav-tabs mb-3" role="tablist">
+                    <li class="nav-item">
+                        <a class="nav-link active" id="packages-tab" data-toggle="tab" href="#packages-results" role="tab" aria-controls="packages-results" aria-selected="true">View Packages</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="documentation-tab" data-toggle="tab" href="#documentation-results" role="tab" aria-controls="documentation-results" aria-selected="false">View Documentation</a>
+                    </li>
+                </ul>
+            }
+            <div class="tab-content">
+                <div class="tab-pane fade show active" id="packages-results" role="tabpanel" aria-labelledby="packages-tab">
+                    <div class="d-lg-flex align-items-lg-center justify-content-lg-between">
+                        <div>
+                            @if (!String.IsNullOrEmpty(Model.SearchTerm) && !moderationQueue)
+                            {
+                                <h3 class="mb-0">Search for "@Model.SearchTerm" Returned @Model.TotalCount <text>Package</text>@if (Model.TotalCount != 1){<text>s</text>}</h3>
+                            }
+                            else
+                            {
+                                if (!moderationQueue)
+                                {
+                                    <h3 class="mb-0">
+                                        @if (Model.TotalCount == 1)
+                                        {<text>There is @Model.TotalCount Community Maintained Package</text>}
+                                        else
+                                        {<text>There are @Model.TotalCount Community Maintained Packages</text>}
+                                    </h3>
+                                }
+                                else
+                                {
+                                    <h3 class="mb-0">
+                                        @{
+                                            var moderationStatus = @Model.ModerationStatus.Remove(@Model.ModerationStatus.IndexOf("-")); // Get everything after -status
+                                            moderationStatus = char.ToUpper(moderationStatus.First()) + moderationStatus.Substring(1).ToLower(); // Capitalize first letter
+                                        }
+                                        @if (!String.IsNullOrEmpty(Model.SearchTerm))
+                                        {
+                                            if (moderationStatus.Equals("All")){ moderationStatus = string.Empty; }
+                                            <text>Search for "@Model.SearchTerm" Returned @Model.TotalCount @moderationStatus Package</text>if(@Model.TotalCount != 1){<text>s</text>}
+                                        }
+                                        else if (moderationStatus.Equals("All")) {
+                                            if (@moderationCount == 1)
+                                            {<text>There is @moderationCount Package</text>}
+                                            else
+                                            {<text>There are @moderationCount Packages</text>}
+                                        }
+                                        else {
+                                            if (@Model.TotalCount == 1)
+                                            {<text>There is @Model.TotalCount @moderationStatus Package</text>}
+                                            else
+                                            {<text>There are @Model.TotalCount @moderationStatus Packages</text>}
+                                        }
+                                        @if (!moderationStatus.Equals("Unknown"))
+                                        {<text> in Moderation</text>}
+                                    </h3>
+                                    if (String.IsNullOrEmpty(Model.SearchTerm))
+                                    {
+                                        <form method="get" action="">
+                                            <fieldset class="form search mb-0">
+                                                <input type="hidden" name="q" value="@Model.SearchTerm" />
+                                                <input type="hidden" name="moderatorQueue" value="true" />
+                                                <button type="submit" name="moderationStatus" value="@Constants.UpdatedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationUpdatedPackageCount Updated</button>
+                                                <span>|</span>
+                                                <button type="submit" name="moderationStatus" value="@Constants.RespondedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationRespondedPackageCount Responded</button>
+                                                <span>|</span>
+                                                <button type="submit" name="moderationStatus" value="@Constants.SubmittedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationSubmittedPackageCount Submitted</button>
+                                                <span>|</span>
+                                                <button type="submit" name="moderationStatus" value="@Constants.WaitingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationWaitingPackageCount Waiting</button>
+                                                <span>|</span>
+                                                <button type="submit" name="moderationStatus" value="@Constants.ReadyModerationStatus" class="bg-transparent border-0 btn-link text-dark">@moderationReadyPackageCount Ready</button>
+                                                <span>|</span>
+                                                <button type="submit" name="moderationStatus" value="@Constants.PendingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationPendingAutoReviewPackageCount Pending</button>
+                                                <input type="hidden" name="prerelease" value="false" />
+                                                <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
+                                            </fieldset>
+                                        </form>
+                                    }
+                                }
+                            }
+                            @if (@Model.TotalCount > 0 && (!moderationQueue || !Model.SearchTerm.IsEmpty()))
+                            {
+                                <p class="mb-0">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
+                            }
+                        </div>
+                        <div>
+                            @if (@Model.TotalCount > 0 && (moderationQueue && Model.SearchTerm.IsEmpty()))
+                            {
+                                <p class="mb-0 mb-lg-2">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
+                            }
+                            <button class="btn btn-primary my-2 mb-sm-0 mt-lg-0" data-toggle="modal" data-target="#package-preferences">Manage Package Preferences</button>
+                            <div class="modal fade" id="package-preferences" tabindex="-1" role="dialog" aria-labelledby="Manage Package Preferences" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h4 class="mb-0">Manage Package Preferences</h4>
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true" class="fas fa-times"></span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="custom-control custom-switch">
+                                                <input type="checkbox" class="custom-control-input" id="preferenceGridView">
+                                                <label class="custom-control-label" for="preferenceGridView">Make grid view your default view?</label>
+                                            </div>
+                                            @if (moderationRole)
+                                            {
+                                                <div class="custom-control custom-switch mt-3">
+                                                    <input type="checkbox" class="custom-control-input" id="preferenceModView">
+                                                    <label class="custom-control-label" for="preferenceModView">Make the Moderator Queue your default view?</label>
+                                                </div>
+                                            }
+                                        </div>
+                                        <div class="modal-footer text-right">
+                                            <button class="btn btn-success btn-preferences">Save Preferences</button>
+                                            <button class="btn btn-danger" data-dismiss="modal" aria-label="Close">Cancel</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <hr class="d-none d-sm-block" />
+                    <nav class="navbar navbar-expand-sm p-0">
+                        <button class="btn btn-primary w-100 d-sm-none" type="button" data-toggle="collapse" data-target="#search-filters" aria-controls="search filters" aria-expanded="false" aria-label="Toggle Search Filters">View Search Filters</button>
+                        <div class="collapse navbar-collapse" id="search-filters">
+                            <div class="navbar-nav d-block w-100 mt-2 mt-sm-0">
+                                <form method="get" action="">
+                                    <fieldset class="form search">
+                                        <input type="hidden" name="q" value="@Model.SearchTerm" />
+                                        <div class="form-row align-items-center">
+                                            <div class="col-sm mb-2 mb-sm-0">
+                                                <select class="form-control" name="moderatorQueue" id="moderatorQueue" aria-label="Sort by Normal View or Moderator Queue">
+                                                    @ViewHelpers.Option("", "Normal View", Model.ModeratorQueue)
+                                                    @ViewHelpers.Option("true", "Moderator Queue", Model.ModeratorQueue)
+                                                </select>
+                                            </div>
+                                            <div class="col-sm mb-2 mb-sm-0 @if (!moderationQueue){<text>d-none</text>}">
+                                                <select class="form-control" name="moderationStatus" id="moderationStatus" aria-label="Moderation Sort Order">
+                                                    @ViewHelpers.Option(Constants.AllModerationStatuses, "All Moderation Statuses", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.SubmittedModerationStatus, "Submitted", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.UpdatedModerationStatus, "Updated", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.PendingModerationStatus, "Pending", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.WaitingModerationStatus, "Waiting", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.RespondedModerationStatus, "Responded", Model.ModerationStatus)
+                                                    @ViewHelpers.Option(Constants.ReadyModerationStatus, "Ready", Model.ModerationStatus)
+                                                </select>
+                                            </div>
+                                            <div class="col-sm mb-2 mb-sm-0">
+                                                <select class="form-control" name="prerelease" id="prerelease" aria-label="Sort by the inclusion of Prerelease Packages">
+                                                    @ViewHelpers.Option("false", "Stable Only", Model.IncludePrerelease)
+                                                    @ViewHelpers.Option("true", "Include Prerelease", Model.IncludePrerelease)
+                                                </select>
+                                            </div>
+                                            <div class="col-sm mb-2 mb-sm-0">
+                                                <select class="form-control" name="sortOrder" id="sortOrder" aria-label="Sort Order">
+                                                    @if (!Model.SearchTerm.IsEmpty())
+                                                    {
+                                                        @ViewHelpers.Option(Constants.RelevanceSortOrder, "Relevance", Model.SortOrder)
+                                                    }
+                                                    @ViewHelpers.Option(Constants.PopularitySortOrder, "Popularity", Model.SortOrder)
+                                                    @ViewHelpers.Option(Constants.AlphabeticSortOrder, "A-Z", Model.SortOrder)
+                                                    @ViewHelpers.Option(Constants.RecentSortOrder, "Recent", Model.SortOrder)
+                                                </select>
+                                            </div>
+                                            <div class="col-12 col-sm text-right">
+                                                <a href="@if(@FullHref.Contains("/packages")){<text>@Url.RouteUrl(RouteName.ListPackages)</text>}else{<text>@Url.RouteUrl(RouteName.SearchResults)</text>}" class="btn btn-outline-primary"><span class="fas fa-sync"></span><span class="d-sm-none d-md-inline-block ml-2 ml-sm-0 ml-md-2">Reset Filters</span></a>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                </form>
+                            </div>
+                        </div>
+                    </nav>
+                    @if (Request.Cookies["preferenceGridView"] != null)
                     {
-                        <h3 class="mb-0">Search for "@Model.SearchTerm" Returned @Model.TotalCount <text>Package</text>@if (Model.TotalCount != 1){<text>s</text>}</h3>
+                        <div class="row pt-3 package-grid-view">
+                            @foreach (var package in Model.Items)
+                            {
+                                <div class="col-lg-6 col-xl-4 mb-4">
+                                    <div class="card h-100">
+                                        @Html.Partial(MVC.Packages.Views._ListPackage, package)
+                                    </div>
+                                </div>
+                            }
+                        </div>
                     }
                     else
                     {
-                        if (!moderationQueue)
-                        {
-                            <h3 class="mb-0">
-                                @if (Model.TotalCount == 1)
-                                {<text>There is @Model.TotalCount Community Maintained Package</text>}
-                                else
-                                {<text>There are @Model.TotalCount Community Maintained Packages</text>}
-                            </h3>
-                        }
-                        else
-                        {
-                            <h3 class="mb-0">
-                                @{
-                                    var moderationStatus = @Model.ModerationStatus.Remove(@Model.ModerationStatus.IndexOf("-")); // Get everything after -status
-                                    moderationStatus = char.ToUpper(moderationStatus.First()) + moderationStatus.Substring(1).ToLower(); // Capitalize first letter
-                                }
-                                @if (!String.IsNullOrEmpty(Model.SearchTerm))
-                                {
-                                    if (moderationStatus.Equals("All")){ moderationStatus = string.Empty; }
-                                    <text>Search for "@Model.SearchTerm" Returned @Model.TotalCount @moderationStatus Package</text>if(@Model.TotalCount != 1){<text>s</text>}
-                                }
-                                else if (moderationStatus.Equals("All")) {
-                                    if (@moderationCount == 1)
-                                    {<text>There is @moderationCount Package</text>}
-                                    else
-                                    {<text>There are @moderationCount Packages</text>}
-                                }
-                                else {
-                                    if (@Model.TotalCount == 1)
-                                    {<text>There is @Model.TotalCount @moderationStatus Package</text>}
-                                    else
-                                    {<text>There are @Model.TotalCount @moderationStatus Packages</text>}
-                                }
-                                @if (!moderationStatus.Equals("Unknown"))
-                                {<text> in Moderation</text>}
-                            </h3>
-                            if (String.IsNullOrEmpty(Model.SearchTerm))
+                        <ul class="list-unstyled pt-3 package-list-view">
+                            @foreach (var package in Model.Items)
                             {
-                                <form method="get" action="">
-                                    <fieldset class="form search mb-0">
-                                        <input type="hidden" name="q" value="@Model.SearchTerm" />
-                                        <input type="hidden" name="moderatorQueue" value="true" />
-                                        <button type="submit" name="moderationStatus" value="@Constants.UpdatedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationUpdatedPackageCount Updated</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.RespondedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationRespondedPackageCount Responded</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.SubmittedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationSubmittedPackageCount Submitted</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.WaitingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationWaitingPackageCount Waiting</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.ReadyModerationStatus" class="bg-transparent border-0 btn-link text-dark">@moderationReadyPackageCount Ready</button>
-                                        <span>|</span>
-                                        <button type="submit" name="moderationStatus" value="@Constants.PendingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationPendingAutoReviewPackageCount Pending</button>
-                                        <input type="hidden" name="prerelease" value="false" />
-                                        <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
-                                    </fieldset>
-                                </form>
+                                <li>
+                                    @Html.Partial(MVC.Packages.Views._ListPackage, package)
+                                </li>
                             }
-                        }
+                        </ul>
                     }
-                    @if (@Model.TotalCount > 0 && (!moderationQueue || !Model.SearchTerm.IsEmpty()))
-                    {
-                        <p class="mb-0">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
-                    }
-                </div>
-                <div>
-                    @if (@Model.TotalCount > 0 && (moderationQueue && Model.SearchTerm.IsEmpty()))
-                    {
-                        <p class="mb-0 mb-lg-2">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
-                    }
-                    <button class="btn btn-primary my-2 mb-sm-0 mt-lg-0" data-toggle="modal" data-target="#package-preferences">Manage Package Preferences</button>
-                    <div class="modal fade" id="package-preferences" tabindex="-1" role="dialog" aria-labelledby="Manage Package Preferences" aria-hidden="true">
-                        <div class="modal-dialog" role="document">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h4 class="mb-0">Manage Package Preferences</h4>
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true" class="fas fa-times"></span>
-                                    </button>
-                                </div>
-                                <div class="modal-body">
-                                    <div class="custom-control custom-switch">
-                                        <input type="checkbox" class="custom-control-input" id="preferenceGridView">
-                                        <label class="custom-control-label" for="preferenceGridView">Make grid view your default view?</label>
-                                    </div>
-                                    @if (moderationRole)
-                                    {
-                                        <div class="custom-control custom-switch mt-3">
-                                            <input type="checkbox" class="custom-control-input" id="preferenceModView">
-                                            <label class="custom-control-label" for="preferenceModView">Make the Moderator Queue your default view?</label>
-                                        </div>
-                                    }
-                                </div>
-                                <div class="modal-footer text-right">
-                                    <button class="btn btn-success btn-preferences">Save Preferences</button>
-                                    <button class="btn btn-danger" data-dismiss="modal" aria-label="Close">Cancel</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <hr class="d-none d-sm-block" />
-            <nav class="navbar navbar-expand-sm p-0">
-                <button class="btn btn-primary w-100 d-sm-none" type="button" data-toggle="collapse" data-target="#search-filters" aria-controls="search filters" aria-expanded="false" aria-label="Toggle Search Filters">View Search Filters</button>
-                <div class="collapse navbar-collapse" id="search-filters">
-                    <div class="navbar-nav d-block w-100 mt-2 mt-sm-0">
-                        <form method="get" action="">
-                            <fieldset class="form search">
-                                <input type="hidden" name="q" value="@Model.SearchTerm" />
-                                <div class="form-row align-items-center">
-                                    <div class="col-sm mb-2 mb-sm-0">
-                                        <select class="form-control" name="moderatorQueue" id="moderatorQueue" aria-label="Sort by Normal View or Moderator Queue">
-                                            @ViewHelpers.Option("", "Normal View", Model.ModeratorQueue)
-                                            @ViewHelpers.Option("true", "Moderator Queue", Model.ModeratorQueue)
-                                        </select>
-                                    </div>
-                                    <div class="col-sm mb-2 mb-sm-0 @if (!moderationQueue){<text>d-none</text>}">
-                                        <select class="form-control" name="moderationStatus" id="moderationStatus" aria-label="Moderation Sort Order">
-                                            @ViewHelpers.Option(Constants.AllModerationStatuses, "All Moderation Statuses", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.SubmittedModerationStatus, "Submitted", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.UpdatedModerationStatus, "Updated", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.PendingModerationStatus, "Pending", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.WaitingModerationStatus, "Waiting", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.RespondedModerationStatus, "Responded", Model.ModerationStatus)
-                                            @ViewHelpers.Option(Constants.ReadyModerationStatus, "Ready", Model.ModerationStatus)
-                                        </select>
-                                    </div>
-                                    <div class="col-sm mb-2 mb-sm-0">
-                                        <select class="form-control" name="prerelease" id="prerelease" aria-label="Sort by the inclusion of Prerelease Packages">
-                                            @ViewHelpers.Option("false", "Stable Only", Model.IncludePrerelease)
-                                            @ViewHelpers.Option("true", "Include Prerelease", Model.IncludePrerelease)
-                                        </select>
-                                    </div>
-                                    <div class="col-sm mb-2 mb-sm-0">
-                                        <select class="form-control" name="sortOrder" id="sortOrder" aria-label="Sort Order">
-                                            @if (!Model.SearchTerm.IsEmpty())
-                                            {
-                                                @ViewHelpers.Option(Constants.RelevanceSortOrder, "Relevance", Model.SortOrder)
-                                            }
-                                            @ViewHelpers.Option(Constants.PopularitySortOrder, "Popularity", Model.SortOrder)
-                                            @ViewHelpers.Option(Constants.AlphabeticSortOrder, "A-Z", Model.SortOrder)
-                                            @ViewHelpers.Option(Constants.RecentSortOrder, "Recent", Model.SortOrder)
-                                        </select>
-                                    </div>
-                                    <div class="col-12 col-sm text-right">
-                                        <a href="@if(@FullHref.Contains("/packages")){<text>@Url.RouteUrl(RouteName.ListPackages)</text>}else{<text>@Url.RouteUrl(RouteName.SearchResults)</text>}" class="btn btn-outline-primary"><span class="fas fa-sync"></span><span class="d-sm-none d-md-inline-block ml-2 ml-sm-0 ml-md-2">Reset Filters</span></a>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        </form>
-                    </div>
-                </div>
-            </nav>
-            @if (Request.Cookies["preferenceGridView"] != null)
-            {
-                <div class="row pt-3 package-grid-view">
-                    @foreach (var package in Model.Items)
-                    {
-                        <div class="col-lg-6 col-xl-4 mb-4">
-                            <div class="card h-100">
-                                @Html.Partial(MVC.Packages.Views._ListPackage, package)
-                            </div>
-                        </div>
-                    }
-                </div>
-            }
-            else
-            {
-                <ul class="list-unstyled pt-3 package-list-view">
-                    @foreach (var package in Model.Items)
-                    {
-                        <li>
-                            @Html.Partial(MVC.Packages.Views._ListPackage, package)
-                        </li>
-                    }
-                </ul>
-            }
 
-            @if (@FullHref.Contains("/packages"))
-            {@ViewHelpers.PreviousNextPager(Model.Pager)}
-            else
-            {@ViewHelpers.PreviousNextPager(Model.PagerSearch)}
-        </div>
-        @if (!String.IsNullOrEmpty(Model.SearchTerm))
-        {
-            <div class="tab-pane fade" id="documentation-results" role="tabpanel" aria-labelledby="documentation-tab">
-                <h2 class="mb-lg-0">Search for "@Model.SearchTerm" Docs and Site Search Results</h2>
-                <hr />
-                <gcse:searchresults-only></gcse:searchresults-only>
+                    @if (@FullHref.Contains("/packages"))
+                    {@ViewHelpers.PreviousNextPager(Model.Pager)}
+                    else
+                    {@ViewHelpers.PreviousNextPager(Model.PagerSearch)}
+                </div>
+                @if (!String.IsNullOrEmpty(Model.SearchTerm))
+                {
+                    <div class="tab-pane fade" id="documentation-results" role="tabpanel" aria-labelledby="documentation-tab">
+                        <h2 class="mb-lg-0">Search for "@Model.SearchTerm" Docs and Site Search Results</h2>
+                        <hr />
+                        <gcse:searchresults-only></gcse:searchresults-only>
+                    </div>
+                }
             </div>
-        }
+        </div>
+        <div class="d-none d-md-block col-md-4 col-xl-3 col-xxxl-2 border-left p-3">
+            @Html.Partial("~/Views/Pages/_CollapsingRightSidebarContent.cshtml")
+        </div>
     </div>
 </section>
 

--- a/chocolatey/Website/Views/Pages/_CollapsingRightSidebar.cshtml
+++ b/chocolatey/Website/Views/Pages/_CollapsingRightSidebar.cshtml
@@ -1,0 +1,5 @@
+﻿<a class="btn btn-primary btn-collapsing-right-sidebar collapsed py-3 d-hash-none d-none @if(!ViewContext.RouteData.Values["Action"].Equals("ListPackages")){<text>d-md-block</text>} shadow" data-toggle="collapse" href="#collapsing-right-sidebar" role="button" aria-expanded="false" aria-controls="collapsing right sidebar"><i class="fas fa-bullhorn"></i></a>
+<nav id="collapsing-right-sidebar" class="collapsing-sidebar collapse shadow pt-3 px-3">
+    <div class="text-right text-md-left mb-3"><a class="h3 collapsed text-secondary" data-toggle="collapse" href="#collapsing-right-sidebar" role="button" aria-expanded="false" aria-controls="collapsing right sidebar"><span class="fas fa-times"></span></a></div>
+    @Html.Partial("~/Views/Pages/_CollapsingRightSidebarContent.cshtml")
+</nav>

--- a/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
+++ b/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
@@ -1,0 +1,75 @@
+﻿<div id="informationCarousel" class="carousel slide carousel-fade information-carousel" data-ride="carousel" data-touch="true" data-interval="6000" style="height: auto;">
+    <div class="carousel-inner px-3" style="height: auto;">
+        <div class="carousel-item active">
+            <div class="card bg-primary mb-0">
+                <div class="card-body text-center">
+                    <h3>Resources</h3>
+                    <p>Watch videos, read documentation, and hear Chocolatey success stories from companies you trust.</p>
+                    <a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "home"})" class="btn btn-light">View Resources</a>
+                </div>
+            </div>
+        </div>
+        <div class="carousel-item">
+            <div class="card bg-success text-white mb-0">
+                <div class="card-body text-center">
+                    <h3>Events</h3>
+                    <p>Find past and upcoming webinars, workshops, and conferences. New events have recently been added!</p>
+                    <a href="@Url.RouteUrl(RouteName.Events, new { eventName = "home" })" class="btn btn-light">View Events</a>
+                </div>
+            </div>
+        </div>
+        <div class="carousel-item">
+            <div class="card bg-medium-dark mb-0">
+                <div class="card-body text-center">
+                    <h3>Courses</h3>
+                    <p>Step-by-step guides for all things Chocolatey! Earn badges as you learn through interactive digital courses.</p>
+                    <a href="@Url.RouteUrl(RouteName.Courses)" class="btn btn-light">View Courses</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<hr />
+<div class="shuffle">
+    <div class="text-center">
+        <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" rel="noreferrer" target="_blank">
+            <img class="img-fluid mb-3" src="@Url.Content("~/content/images/events/01-04.jpg")" alt="The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer" />
+        </a>
+        <p><strong>Tuesday, 22 September 2020<br />9-10 AM CDT (7-8 AM PDT / 2-3 PM GMT)</strong></p>
+        <p class="text-left">
+            Standardising tool sets across different Teams is not always easy... especially when different Teams have traditionally used different approaches and methodologies.
+            In this webinar we will unpack the advantages of a more standard, consistent approach with Puppet & Chocolatey.
+        </p>
+        <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" rel="noreferrer" target="_blank" class="btn btn-primary">Register Now</a>
+        <hr />
+    </div>
+    <div class="text-center">
+        <a href="@Url.RouteUrl(RouteName.Events, new { eventName= "chocolatey-deployments" })">
+            <img class="img-fluid mb-3" src="@Url.Content("~/content/images/events/01-02.jpg")" alt="Webinar: Chocolatey Deployments - Easily Orchestrate Amazing Things!" />
+        </a>
+        <p><strong>Webinar Replay from<br />Tuesday, 23 June 2020</strong></p>
+        <p class="text-left">Chocolatey Central Management now includes the premiere feature of managing endpoints through a Chocolatey-centered solution aka Deployments. We are excited to share what Deployments is all about!</p>
+        <a href="@Url.RouteUrl(RouteName.Events, new { eventName= "chocolatey-deployments" })" class="btn btn-outline-primary">Learn More</a>
+        <a href="https://chocolatey.zoom.us/webinar/register/WN_MPT5b34zQnud8R0nGgpe5A" rel="noreferrer" target="_blank" class="btn btn-primary">Watch Now</a>
+        <hr />
+    </div>
+    <div class="text-center">
+        <h3 class="mb-3"><a class="btn-link" href="@Url.RouteUrl(RouteName.Covid19)">COVID-19 Resources</a></h3>
+        <p class="text-left">Chocolatey Software is working harder than ever to provide solutions and resources for our customers and community. We'll continue to add to this area so check back often.</p>
+        <a href="@Url.RouteUrl(RouteName.Covid19)" class="btn btn-primary">Find Resources</a>
+        <hr />
+    </div>
+    <div class="text-center">
+        <a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "features"})">
+            <img class="img-fluid mb-3" src="@Url.Content("~/content/images/videos/04-01.jpg")" alt="Chocolatey for Business Feature Video Series" />
+        </a>
+        <p class="mb-3"><strong>Chocolatey for Business Feature Video Series</strong></p>
+        <p class="text-left">
+            In this video series, come take a tour of the many features available in our Chocolatey for Business offering.
+            Many organizations choose Chocolatey for Business when they want to scale out their solution across thousands of nodes, deploy rapidly and reliably every time,
+            mitigate risks with a greatly-simplified patching workflow, and access a Support Team that will guide you on your automation journey.
+        </p>
+        <a href="@Url.RouteUrl(RouteName.Resources, new {resourceType = "features"})" class="btn btn-primary">Watch the Series</a>
+        <hr />
+    </div>
+</div>

--- a/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
+++ b/chocolatey/Website/Views/Shared/_TopNavigation.cshtml
@@ -2,18 +2,24 @@
 
 <header class="w-100">
     @Html.Partial("~/Views/Shared/_AlertTop.cshtml")
+    @Html.Partial("~/Views/Pages/_CollapsingRightSidebar.cshtml")
     <nav id="topNav" class="navbar navbar-expand-lg navbar-dark bg-dark">
         <a class="navbar-brand p-0" href="@Url.Home()">
             <img class="d-none d-lg-block" alt="Chocolatey Software" src="@Url.Content("~/content/images/logo_square.svg")" />
             <img class="d-lg-none" alt="Chocolatey Software" src="@Url.Content("~/content/images/logo_small.svg")" />
         </a>
-        <div class="d-flex align-items-center d-lg-none">
-            <button class="btn btn-outline-light btn-nav-toggle mr-3 collapsed" type="button" data-toggle="collapse" data-target="#topNavbar" aria-controls="topNavbar" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="fas fa-bars"></span>
-            </button>
+        <div class="d-flex align-items-center btn-row d-lg-none">
+            <div class="@if(ViewContext.RouteData.Values["Action"].Equals("ListPackages")){<text>mr-md-0</text>}">
+                <button class="btn btn-outline-light btn-nav-toggle" type="button" data-toggle="collapse" data-target="#topNavbar" aria-controls="topNavbar" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="fas fa-bars"></span>
+                </button>
+            </div>
+            <div class="d-md-none">
+                <button class="btn btn-outline-light btn-announcements d-hash-none mt-0" type="button" data-toggle="collapse" data-target="#collapsing-right-sidebar" aria-expanded="false" aria-controls="collapsing right sidebar"><i class="fas fa-bullhorn"></i></button>
+            </div>
             @if (!ViewContext.RouteData.Values["Action"].Equals("ListPackages"))
             {
-                <div class="nav-search d-lg-none">
+                <div class="nav-search">
                     @Html.Partial("~/Views/Shared/_SearchBox.cshtml")
                     <button class="btn btn-outline-light btn-search">
                         <span class="fas fa-search" alt="Search"></span>
@@ -128,7 +134,7 @@
                                         <li>
                                             <a href="@Url.RouteUrl(RouteName.Solutions, new {solutionName = "home"})">Self-Service Anywhere</a>
                                             <p class="d-none d-md-block">
-                                                Chocolatey provides a unique approach to managing your end-user software (desktops / laptops) and can be combined with your existing solutions. 
+                                                Chocolatey provides a unique approach to managing your end-user software (desktops / laptops) and can be combined with your existing solutions.
                                                 Chocolatey for Business (C4B) enables better security, enhanced visibility with centralized reporting, and a self-service GUI. Self-Service Anywhere allows non-administrators to easily access and manage IT approved software from the office, from home, or anywhere they have an internet connection.
                                             </p>
                                         </li>
@@ -241,7 +247,7 @@
                     <a class="nav-link dropdown-toggle" href="#" id="partners" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Partners</a>
                     <div class="dropdown-menu" aria-labelledby="partners">
                         <div class="container">
-                            <div class="row">
+                            <div class="row w-100">
                                 <div class="col-12 d-lg-none">
                                     <a class="goback" href="#"><span class="fas fa-chevron-left"></span> Go Back</a>
                                     <h4 class="text-center">Partners</h4>
@@ -255,8 +261,6 @@
                                 <div class="col-md-6">
                                     <ul>
                                         <li><a href="@Url.RouteUrl(RouteName.Partner)#technology">Technology Partners</a></li>
-                                    </ul>
-                                    <ul>
                                         <li><a href="@Url.RouteUrl(RouteName.Partner)#resellers">Resellers</a></li>
                                     </ul>
                                 </div>

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1479,6 +1479,7 @@
     <Content Include="Import-QuickDeployCertificate.ps1" />
     <Content Include="Content\scss\_ribbons.scss" />
     <Content Include="Content\scss\_countdown.scss" />
+    <Content Include="Content\scss\_collapsing-sidebar.scss" />
     <None Include="optipng.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -1691,8 +1692,10 @@
     <Content Include="Views\Events\Home.cshtml" />
     <Content Include="Views\Events\Files\01-01-EnableYourRemoteWorkforceByImplementingModernInfrastructureWithChocolatey.md" />
     <Content Include="Views\Events\Files\01-02-ChocolateyDeployments.md" />
+    <Content Include="Views\Pages\_CollapsingRightSidebar.cshtml" />
     <Content Include="Views\Events\ChocolateyDeployments.cshtml" />
     <Content Include="Views\Events\Files\01-04-TheBusinessValueOfModernizingYourWindowsInfrastructure.md" />
+    <Content Include="Views\Pages\_CollapsingRightSidebarContent.cshtml" />
     <Content Include="Views\Events\Files\01-03-OperationsAutomationWithOctopusRunbooksAndChocolatey.md" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
An announcement bar has been added that will appear on the right hand
side of the screen while on desktop, and full screen while on mobile.
The announcement bar is slightly different on the package listing page
then on the rest of the website, as it is static and always visible. On
the rest of the website, there is a new button that is located on the
right hand side of the screen that will show/hide this announcement
area when clicked. While on mobile, this switches to a button that is
added to the top navigation bar.

The announcements are set to "shuffle" on reload, so that a user will
potentially see different announcements while navigating throughout the
website.