### PR TITLE
(layout) Adjust Gitter Chat Box for Mobile

### DIFF
--- a/chocolatey/Website/Content/scss/purge.scss
+++ b/chocolatey/Website/Content/scss/purge.scss
@@ -48,7 +48,7 @@
 
 /*Gitter*/
 .gitter-chat-embed {
-    right: 60%;
+    right: 0;
     left: 0;
     border-right: 3px solid #5c9fd8;
 
@@ -65,4 +65,10 @@
 .gitter-open-chat-button {
     right: unset;
     left: 10px;
+}
+
+@media (min-width: 720px) {
+    .gitter-chat-embed {
+        right: 60%;
+    }
 }


### PR DESCRIPTION
While on mobile, the Gitter chat box is very tiny and unreadable. This
slight change in CSS adjust the chat box to take up the entire screen
on a mobile device so that it is easier to type and read.