### PR TITLE
(GH-613) Compute hash using stream 

### DIFF
--- a/chocolatey/Website/Services/CryptographyService.cs
+++ b/chocolatey/Website/Services/CryptographyService.cs
@@ -1,15 +1,15 @@
-﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
 // authors/contributors from ChocolateyGallery
 // at https://github.com/chocolatey/chocolatey.org,
-// and the authors/contributors of NuGetGallery 
+// and the authors/contributors of NuGetGallery
 // at https://github.com/NuGet/NuGetGallery
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chocolatey/Website/Services/CryptographyService.cs
+++ b/chocolatey/Website/Services/CryptographyService.cs
@@ -17,6 +17,7 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -28,6 +29,23 @@ namespace NuGetGallery
     public class CryptographyService : ICryptographyService
     {
         private const int SaltLengthInBytes = 16;
+
+        public string GenerateHash(
+            Stream input,
+            string hashAlgorithmId = Constants.Sha512HashAlgorithmId)
+        {
+            byte[] hashBytes;
+
+            input.Position = 0;
+
+            using (var hashAlgorithm = HashAlgorithm.Create(hashAlgorithmId))
+            {
+                hashBytes = hashAlgorithm.ComputeHash(input);
+            }
+
+            var hash = Convert.ToBase64String(hashBytes);
+            return hash;
+        }
 
         public string GenerateHash(
             byte[] input,
@@ -92,6 +110,14 @@ namespace NuGetGallery
 
                 return HttpServerUtility.UrlTokenEncode(data).Replace('_', '-');
             }
+        }
+
+        public bool ValidateHash(
+            string hash,
+            Stream input,
+            string hashAlgorithmId = Constants.Sha512HashAlgorithmId)
+        {
+            return hash.Equals(GenerateHash(input));
         }
 
         public bool ValidateHash(

--- a/chocolatey/Website/Services/PackageService.cs
+++ b/chocolatey/Website/Services/PackageService.cs
@@ -519,11 +519,8 @@ namespace NuGetGallery
             Trace.TraceInformation("[{0}] - Getting package stream.".format_with(requestInformation));
             using(var packageFileStream = nugetPackage.GetStream())
             {
-                Trace.TraceInformation("[{0}] - Reading all package bytes.".format_with(requestInformation));
-                var packageBytes = packageFileStream.ReadAllBytes();
-
                 Trace.TraceInformation("[{0}] - Generating Hash for package.".format_with(requestInformation));
-                package.Hash = cryptoSvc.GenerateHash(packageBytes);
+                package.Hash = cryptoSvc.GenerateHash(packageFileStream);
 
                 Trace.TraceInformation("[{0}] - Setting Package File Size.".format_with(requestInformation));
                 package.PackageFileSize = packageFileStream.Length;
@@ -698,23 +695,25 @@ namespace NuGetGallery
                         if (extensions.Contains(extension, StringComparer.InvariantCultureIgnoreCase)) fileContent = packageFile.GetStream().ReadToEnd();
                         else if (checksumExtensions.Contains(extension, StringComparer.InvariantCultureIgnoreCase))
                         {
-                            var bytes = packageFile.GetStream().ReadAllBytes();
-                            var md5Hash =
-                                BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(bytes, "MD5")))
-                                            .Replace("-", string.Empty);
-                            var sha1Hash =
-                                BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(bytes, "SHA1")))
-                                            .Replace("-", string.Empty);
+                            using (var packageFileStream = packageFile.GetStream())
+                            {
+                                var md5Hash =
+                                    BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(packageFileStream, "MD5")))
+                                                .Replace("-", string.Empty);
+                                var sha1Hash =
+                                    BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(packageFileStream, "SHA1")))
+                                                .Replace("-", string.Empty);
 
-                            var sha256Hash =
-                               BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(bytes, "SHA256")))
-                                           .Replace("-", string.Empty);
+                                var sha256Hash =
+                                   BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(packageFileStream, "SHA256")))
+                                               .Replace("-", string.Empty);
 
-                            var sha512Hash =
-                               BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(bytes, "SHA512")))
-                                           .Replace("-", string.Empty);
+                                var sha512Hash =
+                                   BitConverter.ToString(Convert.FromBase64String(cryptoSvc.GenerateHash(packageFileStream, "SHA512")))
+                                               .Replace("-", string.Empty);
 
-                            fileContent = string.Format("md5: {0} | sha1: {1} | sha256: {2} | sha512: {3}", md5Hash, sha1Hash, sha256Hash, sha512Hash);
+                                fileContent = string.Format("md5: {0} | sha1: {1} | sha256: {2} | sha512: {3}", md5Hash, sha1Hash, sha256Hash, sha512Hash);
+                            }
                         }
                     }
                 } catch (Exception ex)

--- a/nugetgallery/Website/Services/ICryptographyService.cs
+++ b/nugetgallery/Website/Services/ICryptographyService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace NuGetGallery
 {
@@ -7,12 +8,21 @@ namespace NuGetGallery
         // TODO: combine these into one Generate and Validate method that detects the salt based on the number of bytes
 
         string GenerateHash(
+            Stream input,
+            string hashAlgorithmId = Constants.Sha512HashAlgorithmId);
+
+        string GenerateHash(
             byte[] input,
             string hashAlgorithmId = Constants.Sha512HashAlgorithmId);
 
         string GenerateSaltedHash(
             string input,
             string hashAlgorithmId);
+
+        bool ValidateHash(
+            string hash,
+            Stream input,
+            string hashAlgorithmId = Constants.Sha512HashAlgorithmId);
 
         bool ValidateHash(
             string hash,


### PR DESCRIPTION
Rather than computing it from a byte[]. Using the ReadAllBytes method
is causing an OutOfMemory exception to occur with larger packages. The
ComputeHash method that is being used can also accept a Stream, rather
then a byte[], which should use less memory overall.

Relates to #613 