### PR TITLE
(GH-935) Update Puppet Webinar Time on Home/Events Page

### DIFF
--- a/chocolatey/Website/Views/Events/Files/01-04-TheBusinessValueOfModernizingYourWindowsInfrastructure.md
+++ b/chocolatey/Website/Views/Events/Files/01-04-TheBusinessValueOfModernizingYourWindowsInfrastructure.md
@@ -1,7 +1,7 @@
 IsArchived: false
 Type: webinar
 EventDate: 20200922T14:00:00
-Time: 9-10 AM CDT (7-8 AM PDT / 2-3 PM GMT)
+Time: 3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern
 Duration: 1 hour
 Title: The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer
 Speakers: Rob Reynolds, Nigel Kersten

--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -70,6 +70,13 @@
                 <h4 class="mb-0">WEBINAR</h4>
                 <h1 class="font-weight-bold d-none d-sm-block">The Business Value of Modernizing Your Windows Infrastructure<br />and Bringing Linux & Windows Teams Closer</h1>
                 <h3 class="font-weight-bold d-sm-none">The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer</h3>
+                <h5>
+                    <span class="mr-md-4 mb-1 mb-md-0 d-inline-block"><i class="fas fa-calendar"></i> Tuesday, 22 Septemeber 2020</span>
+                    <br class="d-md-none" />
+                    <span>
+                        <i class="fas fa-clock"></i> 3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern
+                    </span>
+                </h5>
             </div>
             <div class="row divider-row align-items-center my-4">
                 <div class="col-sm-6 mb-3 mb-sm-0">

--- a/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
+++ b/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
@@ -35,7 +35,7 @@
         <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="@Url.Content("~/content/images/events/01-04.jpg")" alt="The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer" />
         </a>
-        <p><strong>Tuesday, 22 September 2020<br />9-10 AM CDT (7-8 AM PDT / 2-3 PM GMT)</strong></p>
+        <p><strong>Tuesday, 22 September 2020<br />3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern</strong></p>
         <p class="text-left">
             Standardising tool sets across different Teams is not always easy... especially when different Teams have traditionally used different approaches and methodologies.
             In this webinar we will unpack the advantages of a more standard, consistent approach with Puppet & Chocolatey.


### PR DESCRIPTION
Updates the time formats shown for the webinar "The Business Value of
Modernizing Your Windows Infrastructure and Bringing Linux & Windows
Teams Closer" on the events page. This also adds the time to the
announcement section on the home page, as that was missing before.