### PR TITLE
(GH-944) Adjust Password Regex Special Characters

### DIFF
--- a/chocolatey/Website/Services/UserService.cs
+++ b/chocolatey/Website/Services/UserService.cs
@@ -292,7 +292,7 @@ namespace NuGetGallery
 
         public ReadOnlyCollection<string> CheckForStrongPassword(string password)
         {
-            Regex passwordSymbolPattern = new Regex(@"[!@#$%^&*(),.?:{}|<>]");
+            Regex passwordSymbolPattern = new Regex(@"[^A-Za-z0-9\s]");
 
             var errors = new List<string>();
 


### PR DESCRIPTION
Adjusts the regex used to detect special characters by not including
any letter character, number, or white space instead of listing out
all the special characters.

Fixes #944 