### PR TITLE
(GH-947) Break Long Titles in Grid View

### DIFF
--- a/chocolatey/Website/Views/Packages/_ListPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/_ListPackage.cshtml
@@ -24,7 +24,7 @@
                     	<span class="@Model.PackageTestResultsStatus"></span>
                     </a>
                 </div>
-                <a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)" title="Learn more about @Model.Title" aria-label="Learn more about @Model.Title" class="h5 font-weight-bold text-dark mb-0 btn-link">@Model.Title <span class="@if(gridView){<text>d-block small</text>}">@Model.Version</span></a>
+                <a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)" title="Learn more about @Model.Title" aria-label="Learn more about @Model.Title" class="h5 font-weight-bold text-dark mb-0 btn-link text-break">@Model.Title <span class="@if(gridView){<text>d-block small</text>}">@Model.Version</span></a>
             </div>
             @*Badges*@
             <div class="@if(gridView){<text>mt-1</text>} d-flex align-items-center">

--- a/chocolatey/Website/Views/Users/Profiles.cshtml
+++ b/chocolatey/Website/Views/Users/Profiles.cshtml
@@ -103,7 +103,7 @@
                                         <span class="@package.PackageTestResultsStatus"></span>
                                     </span>
                                 </div>
-                                <h4 class="mb-0">@package.Title</h4>
+                                <h4 class="mb-0 text-break">@package.Title</h4>
                             </div>
                             <div class="card-body pt-0 pb-3">
                                 <ul class="list-unstyled mb-0">
@@ -149,7 +149,7 @@
                                         <span class="@package.PackageTestResultsStatus"></span>
                                     </span>
                                 </div>
-                                <h4 class="mb-0">@package.Title</h4>
+                                <h4 class="mb-0 text-break">@package.Title</h4>
                             </div>
                             <div class="card-body pt-0 pb-3">
                                 @if (!string.IsNullOrEmpty(package.Summary))
@@ -182,7 +182,7 @@
                                 <div class="card-body d-flex align-items-center p-0">
                                     <div class="p-3 w-75 h-100 d-flex flex-column">
                                         <p class="text-muted mb-0">Badge Achievement</p>
-                                        <h4 class="my-auto py-4">@CourseConstants.GetCourseName(courseAchievement.CourseKey)</h4>
+                                        <h4 class="my-auto py-4 text-break">@CourseConstants.GetCourseName(courseAchievement.CourseKey)</h4>
                                         <ul class="course-list mb-0">
                                             <li class="mod-completed d-flex align-items-center h6 mb-0">Course Completed</li>
                                         </ul>


### PR DESCRIPTION
While in the grid view mode on the packages page, package titles will
now break if the title is too long to fit in the box instead of busting
out of the box. This fixes alignment issues with both the title and the
image placement. A Bootstrap class has been added to support this
feature. See:

https://getbootstrap.com/docs/4.4/utilities/text/#word-break

Fixes #947 