### PR TITLE
(GH-952) Fix Typo on Home Page

### DIFF
--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -71,7 +71,7 @@
                 <h1 class="font-weight-bold d-none d-sm-block">The Business Value of Modernizing Your Windows Infrastructure<br />and Bringing Linux & Windows Teams Closer</h1>
                 <h3 class="font-weight-bold d-sm-none">The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer</h3>
                 <h5>
-                    <span class="mr-md-4 mb-1 mb-md-0 d-inline-block"><i class="fas fa-calendar"></i> Tuesday, 22 Septemeber 2020</span>
+                    <span class="mr-md-4 mb-1 mb-md-0 d-inline-block"><i class="fas fa-calendar"></i> Tuesday, 22 September 2020</span>
                     <br class="d-md-none" />
                     <span>
                         <i class="fas fa-clock"></i> 3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern


### PR DESCRIPTION
Correct typo on home page from "Septemeber" to "September".