### PR TITLE
(GH-956) Prevent `-` Between Letters and Numbers in URL/ Update Doc Links

### DIFF
--- a/chocolatey/Website/App_Start/Routes.cs
+++ b/chocolatey/Website/App_Start/Routes.cs
@@ -332,6 +332,7 @@ namespace NuGetGallery
             // Documentation redirects
             routes.Redirect(r => r.MapRoute("InstallRedirect", "docs/install")).To(docsRoute, new { docName = "installation" });
             routes.Redirect(r => r.MapRoute("FeaturesShimsRedirect", "docs/features-shims")).To(docsRoute, new { docName = "features-shim" });
+            routes.Redirect(r => r.MapRoute("ChocolateyInstallPS1", "docs/chocolatey-install-ps-1")).To(docsRoute, new { docName = "chocolatey-install-ps1" });
 
             // Add in Docs route after redirects have been made
             routes.Add(RouteName.Docs, docsRoute);

--- a/chocolatey/Website/Controllers/DocumentationController.cs
+++ b/chocolatey/Website/Controllers/DocumentationController.cs
@@ -136,11 +136,6 @@ namespace NuGetGallery.Controllers
                             hyphenatedValue.Append("-");
                         }
 
-                        if (Char.IsDigit(valueChar) && !Char.IsDigit(previousChar) && hyphenatedValue.Length != 0)
-                        {
-                            hyphenatedValue.Append("-");
-                        }
-
                         previousChar = valueChar;
                         hyphenatedValue.Append(valueChar.to_string());
                     }
@@ -224,11 +219,6 @@ namespace NuGetGallery.Controllers
                 }
 
                 if (Char.IsUpper(valueChar) && hyphenatedValue.Length != 0 && !Char.IsUpper(previousChar) && !fileName.Contains("-"))
-                {
-                    hyphenatedValue.Append("-");
-                }
-
-                if (Char.IsDigit(valueChar) && !Char.IsDigit(previousChar) && hyphenatedValue.Length != 0)
                 {
                     hyphenatedValue.Append("-");
                 }

--- a/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
+++ b/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
@@ -207,6 +207,7 @@
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-ssl-setup" })">QDE SSL/TLS Setup</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-firewall-changes" })">QDE Firewall Changes</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-client-setup" })">QDE Client Setup</a></li>
+                                        <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-internet-setup-v1" })">QDE Internet Setup v1</a></li>
                                     </ul>
                                 </div>
                                 @*Chocolatey Central Management*@


### PR DESCRIPTION
In this PR:

* Updates the left side documentation navigation to include a link to the QDE Internet Setup v1 page.
* Address issue to prevent a `-` character to be inserted between a letter and a number when a URL is converted in the documentation area.

Fixes #956