### PR TITLE
(GH-960) Make Carousel Prev/Next Buttons Function

### DIFF
--- a/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
+++ b/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
@@ -4,7 +4,7 @@
 <input id="announcementCount" value="4" type="hidden" />
 
 <div id="announcementCount"></div>
-<div id="informationCarousel" class="carousel slide carousel-fade information-carousel" data-ride="carousel" data-touch="true" data-interval="6000" style="height: auto;">
+<div id="announcementCarousel" class="carousel slide carousel-fade information-carousel" data-ride="carousel" data-touch="true" data-interval="6000" style="height: auto;">
     <div class="carousel-inner px-3" style="height: auto;">
         <div class="carousel-item active">
             <div class="card bg-primary mb-0">


### PR DESCRIPTION
The prev/next buttons on any carousel item currently do not transition
between slides. This was due to a recent addition of the announcement
flyout, where a carousel was added with the same ID that may be found
on other pages. When the same ID is on the page twice, it breaks the
carousel. The ID has been changed to be unique and not match any other
carousel used throughout the website. Now, the prev/next buttons work
as intended.