### PR TITLE
(GH-963) Convert Documentation .md Files to .pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,12 @@ App_Data
 /chocolatey/Website/Content/dist
 /chocolatey/Website/node_modules
 /chocolatey/Website/chocolatey-styleguide.zip
+/chocolatey/Website/Content/Pdf/chocolatey-pdf.min.css
 snags/
 _AzurePackage
 *.sln.docstates
 *.bak
+Temp_PDF
 
 .DS_Store
 Thumbs.db

--- a/chocolatey/Website/Content/Pdf/runnings.js
+++ b/chocolatey/Website/Content/Pdf/runnings.js
@@ -1,0 +1,18 @@
+module.exports = {
+    header: {
+        height: '2cm',
+        contents: function (pageNum) {
+            if (pageNum == 1) {
+                return '<header class="pdf-header" style="padding-bottom: 20px;"><h2 style="text-align:center;margin:0;">Chocolatey Software Documentation</h2></header>'
+            }
+            return ''
+        }
+    },
+
+    footer: {
+        height: '1.5cm',
+        contents: function (pageNum, numPages) {
+            return '<footer class="pdf-footer" style="padding-top:20px;"><p style="float:left;width:33.33%;margin:0;font-size:10px;">' + new Date().toDateString() + '</p><p style="float:left;width:33.33%;margin:0;font-size:10px;text-align:center;">&copy; 2020 Chocolatey Software, Inc.</p><p style="float:right;width:33.33%;margin:0;font-size:10px;text-align:right;">Page ' + pageNum + ' of ' + numPages + '</p></footer>'
+        }
+    }
+}

--- a/chocolatey/Website/Content/scss/_chocolatey-pdf-variables.scss
+++ b/chocolatey/Website/Content/scss/_chocolatey-pdf-variables.scss
@@ -1,0 +1,66 @@
+// Variables
+$gray-100: #f8f9fa;
+$white: #ffffff;
+
+// Default Colors
+$blue: #5c9fd8;
+$red: #f4516c;
+$green: #36bc98;
+$gray-800: #202f3c; // dark
+$medium-light: #e9ecef;
+$medium: #2f6492;
+$medium-dark: #1a375a;
+
+// FontAwesome Pro
+$fa-font-path: "../../Content/fonts";
+
+// Body & Font
+$font-size-base: .9rem;
+$enable-responsive-font-sizes: true;
+$font-family-sans-serif: 'PT Sans', sans-serif;
+
+// Links
+$link-hover-decoration: none;
+
+// Buttons
+$input-btn-padding-y-sm: 0;
+$input-btn-padding-x-sm: 6px;
+$btn-font-weight: 700;
+
+// Tooltips
+$tooltip-bg: darken($blue, 15%);
+
+// Cards
+$card-border-radius: 0;
+$card-inner-border-radius: 0;
+$card-border-width: 0;
+
+// Alerts
+$alert-border-radius: 0;
+$alert-border-width: 0;
+
+// Custom Select
+$custom-select-indicator: "";
+$input-border-color: $blue;
+$input-disabled-bg: $white;
+
+// Carousel
+$carousel-indicator-active-bg: $blue;
+$carousel-control-color: $blue;
+$carousel-control-opacity: 1;
+$carousel-control-hover-opacity: .7;
+
+// Breadcrumbs
+$breadcrumb-padding-y: 0;
+$breadcrumb-padding-x: 0;
+$breadcrumb-border-radius: 0;
+$breadcrumb-margin-bottom: 0;
+$breadcrumb-bg: transparent;
+
+// Custom Select
+$custom-select-indicator: "";
+$input-border-color: $blue;
+$custom-control-indicator-size: 1.5rem;
+
+// Tabs
+$nav-tabs-link-active-bg: $white;

--- a/chocolatey/Website/Content/scss/_print.scss
+++ b/chocolatey/Website/Content/scss/_print.scss
@@ -1,0 +1,60 @@
+// Syntax Highlighting
+.hljs {
+    background: $light !important;
+    padding: 15px !important;
+    margin: 15px important;
+}
+.hljs-string, .hljs-title, .hljs-constant, .hljs-parent, .hljs-tag .hljs-value, .hljs-rules .hljs-value, .hljs-preprocessor, .hljs-pragma, .haml .hljs-symbol, .ruby .hljs-symbol, .ruby .hljs-symbol .hljs-string, .hljs-template_tag, .django .hljs-variable, .smalltalk .hljs-class, .hljs-addition, .hljs-flow, .hljs-stream, .bash .hljs-variable, .apache .hljs-tag, .apache .hljs-cbracket, .tex .hljs-command, .tex .hljs-special, .erlang_repl .hljs-function_or_atom, .asciidoc .hljs-header, .markdown .hljs-header, .coffeescript .hljs-attribute {
+    color: $danger !important;
+}
+.hljs-number, .hljs-date, .hljs-regexp, .hljs-literal, .hljs-hexcolor, .smalltalk .hljs-symbol, .smalltalk .hljs-char, .go .hljs-constant, .hljs-change, .lasso .hljs-variable, .makefile .hljs-variable, .asciidoc .hljs-bullet, .markdown .hljs-bullet, .asciidoc .hljs-link_url, .markdown .hljs-link_url {
+    color: $success !important;
+}
+
+.hljs-label, .hljs-javadoc, .ruby .hljs-string, .hljs-decorator, .hljs-filter .hljs-argument, .hljs-localvars, .hljs-array, .hljs-attr_selector, .hljs-important, .hljs-pseudo, .hljs-pi, .haml .hljs-bullet, .hljs-doctype, .hljs-deletion, .hljs-envvar, .hljs-shebang, .apache .hljs-sqbracket, .nginx .hljs-built_in, .tex .hljs-formula, .erlang_repl .hljs-reserved, .hljs-prompt, .asciidoc .hljs-link_label, .markdown .hljs-link_label, .vhdl .hljs-attribute, .clojure .hljs-attribute, .asciidoc .hljs-attribute, .lasso .hljs-attribute, .coffeescript .hljs-property, .hljs-phony {
+    color: $primary !important;
+}
+
+// Tables
+table {
+    width: 100%;
+    margin-bottom: $spacer;
+    color: $table-color;
+    background-color: $table-bg;
+    border: $table-border-width solid $table-border-color;
+
+    th,
+    td {
+        padding: $table-cell-padding;
+        vertical-align: top;
+        border: $table-border-width solid $table-border-color;
+    }
+
+    thead th {
+        vertical-align: bottom;
+        border-bottom: (2 * $table-border-width) solid $table-border-color;
+        color: $table-head-color;
+        background-color: $table-head-bg;
+        border-color: $table-border-color;
+    }
+
+    thead {
+        th, td {
+            border-bottom-width: 2 * $table-border-width;
+        }
+    }
+
+    tbody + tbody {
+        border-top: (2 * $table-border-width) solid $table-border-color;
+    }
+
+    tbody tr:nth-of-type(#{$table-striped-order}) {
+        background-color: $table-accent-bg;
+    }
+}
+
+@each $color, $value in $theme-colors {
+    @include table-row-variant($color, theme-color-level($color, $table-bg-level), theme-color-level($color, $table-border-level));
+}
+
+@include table-row-variant(active, $table-active-bg);

--- a/chocolatey/Website/Content/scss/chocolatey-pdf.scss
+++ b/chocolatey/Website/Content/scss/chocolatey-pdf.scss
@@ -1,0 +1,27 @@
+// Variable overrides
+@import "Content/scss/chocolatey-pdf-variables";
+
+// Bootstrap
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/mixins";
+@import "node_modules/bootstrap/scss/reboot";
+@import "node_modules/bootstrap/scss/type";
+@import "node_modules/bootstrap/scss/images";
+@import "node_modules/bootstrap/scss/code";
+@import "node_modules/bootstrap/scss/buttons";
+
+// FontAwesome
+@import "node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "node_modules/@fortawesome/fontawesome-free/scss/solid.scss";
+@import "node_modules/@fortawesome/fontawesome-free/scss/brands.scss";
+
+// Aditional custom styles
+@import "Content/scss/base";
+@import "Content/scss/lists";
+@import "Content/scss/icons";
+@import "Content/scss/tabs";
+@import "Content/scss/status-icons";
+@import "Content/scss/cards";
+@import "Content/scss/callouts";
+@import "Content/scss/print";

--- a/chocolatey/Website/Scripts/documentation/documentation.js
+++ b/chocolatey/Website/Scripts/documentation/documentation.js
@@ -2,6 +2,13 @@
 anchors.options = { placement: 'left' };
 anchors.add();
 
+// PDF Download Links
+var downloadPdfLink = location.pathname.substr(location.pathname.lastIndexOf('/') + 1);
+if (downloadPdfLink == 'docs') {
+    downloadPdfLink = 'home';
+}
+$('.btn-pdf-download').attr('href', 'https://files.chocolatey.org/docs/' + downloadPdfLink + '.pdf');
+
 // Syntax and Tables
 $('pre').addClass('line-numbers border py-2');
 $('pre:not([class*="language-"])').addClass('language-none');

--- a/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
+++ b/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
@@ -268,6 +268,9 @@
                     </nav>
                 </div>
                 <div class="col-12 col-md-9 col-xl-8 py-3 py-lg-5 pl-md-5 docs-body">
+                    <div class="text-right">
+                        <a href="#" class="btn btn-outline-success btn-pdf-download mb-3" download><i class="fas fa-file-pdf"></i> Download Doc to PDF</a>
+                    </div>
                     @RenderBody()
                 </div>
                 <div class="d-none d-xl-block col-xl-2 docs-right">

--- a/chocolatey/Website/gulpfile.js
+++ b/chocolatey/Website/gulpfile.js
@@ -7,35 +7,42 @@ const gulp = require("gulp"),
     uglify = require("gulp-uglify"),
     pump = require("pump"),
     zipfiles = require("gulp-zip"),
+    markdownPdf = require('gulp-markdown-pdf'),
+    split = require("split"),
+    through = require("through"),
+    duplexer = require("duplexer"),
+    rename = require('gulp-rename'),
     dist = "Content/dist";
     sass.compiler = require('node-sass');
+
+const { series, parallel, src, dest } = require('gulp');
 
 function clean() {
     return del([dist, "chocolatey-styleguide.zip"]);
 }
 
 function compileSASS() {
-    return gulp.src("Content/scss/*.scss")
+    return src(["Content/scss/*.scss", "!Content/scss/chocolatey-pdf.scss"])
         .pipe(sass().on('error', sass.logError))
-        .pipe(gulp.dest(dist));
+        .pipe(dest(dist));
 }
 
 function purge() {
-    return gulp.src("Content/dist/chocolatey.css")
+    return src("Content/dist/chocolatey.css")
         .pipe(purgecss({
             content: ["Views/**/*.cshtml", "App_Code/ViewHelpers.cshtml", "Errors/*.*", "Scripts/custom.js", "Scripts/packages/package-details.js", "Content/scss/_search.scss", "Scripts/easymde/easymde.min.js"]
         }))
-        .pipe(gulp.dest("Content/dist/tmp"));
+        .pipe(dest("Content/dist/tmp"));
 }
 
 function optimize() {
-    return gulp.src(["Content/dist/tmp/chocolatey.css", "Content/dist/purge.css"])
+    return src(["Content/dist/tmp/chocolatey.css", "Content/dist/purge.css"])
         .pipe(concat("chocolatey.slim.css"))
         .pipe(cleanCSS({
             level: 1,
             compatibility: 'ie8'
         }))
-        .pipe(gulp.dest(dist))
+        .pipe(dest(dist))
         .on('end', function () {
             del(["Content/dist/purge.css", "Content/dist/tmp"]);
         });
@@ -45,41 +52,41 @@ function optimize() {
 
 // First copy files
 function copyFonts() {
-    return gulp.src("Content/fonts/*.*")
+    return src("Content/fonts/*.*")
         .pipe(gulp.dest("styleguide/fonts"));
 }
 function copyCSS() {
-    return gulp.src(["Content/prism/prism.css", "Content/dist/chocolatey.css", "Content/dist/chocolatey.slim.css"])
-        .pipe(gulp.dest("styleguide/css"));
+    return src(["Content/prism/prism.css", "Content/dist/chocolatey.css", "Content/dist/chocolatey.slim.css"])
+        .pipe(dest("styleguide/css"));
 }
 function copyTmpJS() {
-    return gulp.src(["Scripts/*.js"])
-        .pipe(gulp.dest("styleguide/tmp"));
+    return src(["Scripts/*.js"])
+        .pipe(dest("styleguide/tmp"));
 }
 function copyJS() {
-    return gulp.src("Scripts/prism/prism.js")
-        .pipe(gulp.dest("styleguide/js"));
+    return src("Scripts/prism/prism.js")
+        .pipe(dest("styleguide/js"));
 }
 
 // Second optimize CSS
 function cssStyleguide() {
-    return gulp.src("styleguide/css/*.css")
+    return src("styleguide/css/*.css")
         .pipe(cleanCSS({
             level: 1,
             compatibility: 'ie8'
         }))
-        .pipe(gulp.dest("styleguide/css"));
+        .pipe(dest("styleguide/css"));
 }
 
 // Next concat JS files in temp folder
 function jsStyleguideConcat() {
-    return gulp.src([
+    return src([
         "styleguide/tmp/jquery-3.5.1.js",
         "styleguide/tmp/bootstrap.bundle.js",
         "styleguide/tmp/clipboard.js",
         "styleguide/tmp/custom.js"])
         .pipe(concat("chocolatey.js"))
-        .pipe(gulp.dest("styleguide/js"))
+        .pipe(dest("styleguide/js"))
         .on('end', function () {
             del("styleguide/tmp");
         });
@@ -88,9 +95,9 @@ function jsStyleguideConcat() {
 // Then Optimize JS
 function jsStyleguide(cb) {
     pump([
-        gulp.src("styleguide/js/*.js"),
+        src("styleguide/js/*.js"),
         uglify(),
-        gulp.dest("styleguide/js")
+        dest("styleguide/js")
     ],
         cb
     );
@@ -98,13 +105,94 @@ function jsStyleguide(cb) {
 
 // Zip it all up and delete temporary styleguide folder
 function zip() {
-    return gulp.src("styleguide/*/*.*")
+    return src("styleguide/*/*.*")
         .pipe(zipfiles("chocolatey-styleguide.zip"))
-        .pipe(gulp.dest("./"))
+        .pipe(dest("./"))
         .on('end', function () {
             del(["styleguide", "Content/dist/chocolatey.css"]);
         });
 }
 
-// Task
-gulp.task("default", gulp.series(clean, compileSASS, purge, optimize, copyFonts, copyCSS, copyTmpJS, copyJS, cssStyleguide, jsStyleguideConcat, jsStyleguide, zip));
+// Docs to PDF
+function cleanDocs() {
+    return del(["../../Temp_PDF", "Content/Pdf/*.css"], { force: true });
+}
+
+function pdfCss() {
+    return src("Content/scss/chocolatey-pdf.scss")
+        .pipe(sass().on('error', sass.logError))
+        .pipe(purgecss({
+            content: ["Views/Documentation/*.cshtml", "Views/Documentation/Files/*.md", "Scripts/custom.js", "Scripts/bootstrap.bundle.js", "Content/scss/_print.scss"]
+        }))
+        .pipe(cleanCSS({
+            level: 1,
+            compatibility: 'ie8'
+        }))
+        .pipe(rename({ suffix: '.min' }))
+        .pipe(dest("Content/Pdf"))
+}
+
+function preProcessMd() {
+    var splitter = split({ trailing: false })
+    var docsUrl = "https://chocolatey.org/docs/";
+    var urlOne = /\[\[((?:(?!\[\[).)*?)\|(.*?)]]/g;
+    var urlTwo = /(\[(.*?)\])\(#(.*?)\)/g;
+    var urlThree = /\[(.*?)\]\((.*?)\)/g;
+    var urlImg = /(\()(images)/g;
+    var multilineComment = /^\s*<!--\s*$[^]*?^\s*-->\s*$/gm;
+    var replacer = through(function (data) {
+        this.queue(
+            data
+                .replace(urlOne, (_, x, y) => `[${x}](${docsUrl}${y.replace(/(?!^)[A-Z]/g, '-$&').toLowerCase()})`)
+                .replace(urlTwo, "$2")
+                .replace(urlThree, (_, x, y) => `[${x}](${y.replace(/f-a-q/g, "faq").replace(/p-s1/g, "ps1").replace(/---/g, '-').replace(/--/g, '-').toLowerCase()})`)
+                .replace(urlImg, "$1$2".replace("$2", "content/images/docs"))
+                .replace(multilineComment, "")
+            + "\n"
+        )
+    })
+    
+    splitter.pipe(replacer)
+        .on('error', function (err) {
+            console.log(err)
+        })
+    return duplexer(splitter, replacer)
+}
+
+function docsToPdf() {
+    return src(["Views/Documentation/Files/*.md", "!Views/Documentation/Files/_README.md"])
+        .pipe(markdownPdf({
+            preProcessMd: preProcessMd,
+            remarkable: {
+                html: true
+            },
+            paperBorder: "1cm",
+            runningsPath: "Content/Pdf/runnings.js",
+            cssPath: "Content/Pdf/chocolatey-pdf.min.css"
+        }))
+        .pipe(rename(function (path) {
+            path.basename = path.basename
+                .replace("ChocolateyFAQs", "ChocolateyFaqs")
+                .replace(/piKey/g, "pikey")
+                .replace(/MyGet/g, "Myget")
+                .replace(/(^|[\s-])\S/g, function (match) { return match.toUpperCase() }) // Capitolize letter after a -
+                .replace(/-/g, "") // Remove -
+                .replace(/(?!^)[A-Z]/g, '-$&') // Add - before capitol letter
+                .replace(/P-S1/g, "ps1")
+                .toLowerCase();
+            console.log("Processed: " + path.basename + ".pdf");
+        }))
+        .pipe(dest("../../Temp_PDF"))
+        .on('end', function () {
+            console.log("Complete! Files are located in chocolatey.org\\Temp_PDF\\. Please delete this folder after uploading.")
+        })
+}
+
+// Tasks
+exports.build = series(clean, compileSASS, purge, optimize);
+exports.createZip = series(copyFonts, copyCSS, copyTmpJS, copyJS, cssStyleguide, jsStyleguideConcat, jsStyleguide, zip);
+exports.convertDocsToPdf = series(cleanDocs, pdfCss, docsToPdf);
+
+
+// Default Task
+exports.default = series(exports.build, exports.createZip);

--- a/chocolatey/Website/package-lock.json
+++ b/chocolatey/Website/package-lock.json
@@ -146,6 +146,15 @@
         "readable-stream": "^2.0.6"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -296,6 +305,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
     "async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
@@ -340,6 +355,15 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "autolinker": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.14.1.tgz",
+      "integrity": "sha512-yvsRHIaY51EYDml6MGlbqyJGfl4n7zezGYf+R7gvM8c5LNpRGc4SISkvgAswSS8SWxk/OrGCylKV9mJyVstz7w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -776,6 +800,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -1029,6 +1059,12 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1116,6 +1152,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -1298,6 +1340,18 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1327,6 +1381,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -1450,6 +1513,17 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -1458,6 +1532,18 @@
       "requires": {
         "graceful-fs": "^4.1.11",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -1772,6 +1858,29 @@
         "concat-with-sourcemaps": "^1.0.0",
         "through2": "^2.0.0",
         "vinyl": "^2.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
+    "gulp-markdown-pdf": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-markdown-pdf/-/gulp-markdown-pdf-8.0.0.tgz",
+      "integrity": "sha512-hhne0YhSvkd8cFcJ872ZI20a4dQT90d1/GCFGMmjpOsjtei7L/syUkSrhKArxyqo7sPvwF7o4H4YuJt5vTWthQ==",
+      "dev": true,
+      "requires": {
+        "markdown-pdf": "^10.0.0",
+        "plugin-error": "^1.0.0",
+        "through2": "^3.0.0"
       }
     },
     "gulp-purgecss": {
@@ -1784,7 +1893,25 @@
         "plugin-error": "^1.0.1",
         "purgecss": "^1.3.0",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
+    },
+    "gulp-rename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+      "dev": true
     },
     "gulp-sass": {
       "version": "4.1.0",
@@ -1816,6 +1943,16 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
         }
       }
     },
@@ -1835,6 +1972,18 @@
         "through2": "^2.0.0",
         "uglify-js": "^3.0.5",
         "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "gulp-zip": {
@@ -1898,6 +2047,16 @@
             "arr-diff": "^1.0.1",
             "arr-union": "^2.0.1",
             "extend-shallow": "^1.1.2"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1994,6 +2153,22 @@
           }
         }
       }
+    },
+    "hasha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "highlight.js": {
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -2270,6 +2445,12 @@
         "is-unc-path": "^1.0.0"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -2379,6 +2560,15 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2397,11 +2587,26 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "kew": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "knockout": {
       "version": "3.5.1",
@@ -2569,6 +2774,35 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "markdown-pdf": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-pdf/-/markdown-pdf-10.0.0.tgz",
+      "integrity": "sha512-o3lFfAOTpCgCXEXpNN86RaCVGE1YlxjWuAJ79XevAPoTyCBsl06BWhnFogYedg+JZxPjB3LWsA8JxZiCjsPPLA==",
+      "dev": true,
+      "requires": {
+        "commander": "^3.0.0",
+        "duplexer": "^0.1.1",
+        "extend": "^3.0.2",
+        "highlight.js": "^9.15.9",
+        "phantomjs-prebuilt": "^2.1.3",
+        "remarkable": "^2.0.0",
+        "stream-from-to": "^1.4.2",
+        "through2": "^3.0.1",
+        "tmp": "^0.1.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "marked": {
@@ -3182,11 +3416,34 @@
         }
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      }
     },
     "pify": {
       "version": "3.0.0",
@@ -3267,6 +3524,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "pseudomap": {
@@ -3526,6 +3789,16 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      }
+    },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -3545,6 +3818,18 @@
         "remove-bom-buffer": "^3.0.0",
         "safe-buffer": "^5.1.0",
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "remove-trailing-separator": {
@@ -3617,6 +3902,15 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "request-progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "dev": true,
+      "requires": {
+        "throttleit": "^1.0.0"
       }
     },
     "require-directory": {
@@ -3877,6 +4171,12 @@
         "sver-compat": "^1.5.0"
       }
     },
+    "series-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/series-stream/-/series-stream-1.0.1.tgz",
+      "integrity": "sha1-MRoJxcHVoJFECDLhpICkdADxAF0=",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4082,6 +4382,15 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4090,6 +4399,12 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -4149,6 +4464,18 @@
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
       "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
       "dev": true
+    },
+    "stream-from-to": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/stream-from-to/-/stream-from-to-1.4.3.tgz",
+      "integrity": "sha1-snBHPrxRTnNhVyfF0vdrIplB35Q=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "concat-stream": "^1.4.7",
+        "mkdirp": "^0.5.0",
+        "series-stream": "^1.0.1"
+      }
     },
     "stream-shift": {
       "version": "1.0.1",
@@ -4233,14 +4560,26 @@
         "inherits": "2"
       }
     },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
       }
     },
     "through2-filter": {
@@ -4251,6 +4590,18 @@
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "time-stamp": {
@@ -4263,6 +4614,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
+    "tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^2.6.3"
+      }
     },
     "to-absolute-glob": {
       "version": "2.0.2",
@@ -4323,6 +4683,18 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "tough-cookie": {
@@ -4349,6 +4721,12 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -4597,6 +4975,18 @@
         "value-or-function": "^3.0.0",
         "vinyl": "^2.0.0",
         "vinyl-sourcemap": "^1.1.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
       }
     },
     "vinyl-sourcemap": {
@@ -4721,6 +5111,16 @@
       "requires": {
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yazl": {

--- a/chocolatey/Website/package.json
+++ b/chocolatey/Website/package.json
@@ -2,15 +2,21 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
     "del": "^3.0.0",
+    "duplexer": "^0.1.2",
     "gulp": "^4.0.2",
     "gulp-clean-css": "^4.2.0",
     "gulp-concat": "^2.6.1",
+    "gulp-markdown-pdf": "^8.0.0",
     "gulp-purgecss": "^1.2.0",
+    "gulp-rename": "^2.0.0",
     "gulp-sass": "^4.0.2",
     "gulp-uglify": "^3.0.2",
     "gulp-zip": "^4.2.0",
     "jquery-countdown": "^2.2.0",
-    "node-sass": "^4.14.1"
+    "markdown-pdf": "^10.0.0",
+    "node-sass": "^4.14.1",
+    "split": "^1.0.1",
+    "through": "^2.3.8"
   },
   "dependencies": {
     "anchor-js": "^4.2.2",


### PR DESCRIPTION
Converts all of the documentation files into a .pdf file by running the
gulp task `gulp convertDocsToPdf`. By doing so, a new folder named
`Temp_PDF` is created at the top level of the project, which all the
PDF's are then stored in. The intention is to run this gulp task,
upload the PDF's and then delete this temp folder.

A button has been added to each documentation page that allows the user
to download the current page they are viewing to a PDF document.