### PR TITLE
(GH-965) Add QDE v1 Links to Docs Nav

### DIFF
--- a/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
+++ b/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
@@ -207,7 +207,19 @@
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-ssl-setup" })">QDE SSL/TLS Setup</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-firewall-changes" })">QDE Firewall Changes</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-client-setup" })">QDE Client Setup</a></li>
-                                        <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-internet-setup-v1" })">QDE Internet Setup v1</a></li>
+                                        <li>
+                                            <a class="collapsed d-block" data-toggle="collapse" href="#quick-deployment-environment-v1" role="button" aria-expanded="false" aria-controls="quick-deployment-environment-v1" title="Quick Deployment Environment V1">QDE v1</a>
+                                            <div class="collapse" id="quick-deployment-environment-v1">
+                                                <ul>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-setup-v1" })">QDE Setup v1</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-desktop-readme-v1" })">QDE Desktop ReadMe Files v1</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-ssl-setup-v1" })">QDE SSL/TLS Setup v1</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-firewall-changes-v1" })">QDE Firewall Changes v1</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-client-setup-v1" })">QDE Client Setup v1</a></li>
+                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-internet-setup-v1" })">QDE Internet Setup v1</a></li>
+                                                </ul>
+                                            </div>
+                                        </li>
                                     </ul>
                                 </div>
                                 @*Chocolatey Central Management*@


### PR DESCRIPTION
Adds the QDE v1 links to the left side navigation in the documentation
area, under the existing QDE dropdown.

![qdev1](https://user-images.githubusercontent.com/42750725/93243330-a8843300-f74d-11ea-83f7-a03766cd1d26.png)
