### PR TITLE
(GH-915) Allow Software Author Field to Wrap

### DIFF
--- a/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
+++ b/chocolatey/Website/Views/Packages/DisplayPackage.cshtml
@@ -152,7 +152,7 @@
             <ul class="list-unstyled">
                 @foreach (var author in Model.Authors)
                 {
-                    <li>@author.Name.clean_html()</li>
+                    <li class="text-break">@author.Name.clean_html()</li>
                 }
             </ul>
             @if (@Model.Tags.AnySafe())
@@ -360,7 +360,7 @@
             <ul class="list-unstyled mb-0 pb-1 border-bottom">
                 @foreach (var author in Model.Authors)
                 {
-                    <li>@author.Name.clean_html()</li>
+                    <li class="text-break">@author.Name.clean_html()</li>
                 }
             </ul>
             @if (@Model.Tags.AnySafe())


### PR DESCRIPTION
Allows the Software Author Field to wrap instead of breaking out of
it's bounding box. This applies mostly when the Software Author field
contains a url, or a long word without any breaks.
