### PR TITLE
(GH-965) Update QDE Doc Navigation Links

### DIFF
--- a/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
+++ b/chocolatey/Website/Views/Documentation/DocumentationLayout.cshtml
@@ -207,6 +207,7 @@
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-ssl-setup" })">QDE SSL/TLS Setup</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-firewall-changes" })">QDE Firewall Changes</a></li>
                                         <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-client-setup" })">QDE Client Setup</a></li>
+                                        <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-internet-setup" })">QDE Internet Setup</a></li>
                                         <li>
                                             <a class="collapsed d-block" data-toggle="collapse" href="#quick-deployment-environment-v1" role="button" aria-expanded="false" aria-controls="quick-deployment-environment-v1" title="Quick Deployment Environment V1">QDE v1</a>
                                             <div class="collapse" id="quick-deployment-environment-v1">
@@ -216,7 +217,6 @@
                                                     <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-ssl-setup-v1" })">QDE SSL/TLS Setup v1</a></li>
                                                     <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-firewall-changes-v1" })">QDE Firewall Changes v1</a></li>
                                                     <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-client-setup-v1" })">QDE Client Setup v1</a></li>
-                                                    <li><a href="@Url.RouteUrl(RouteName.Docs, new { docName = "quick-deployment-internet-setup-v1" })">QDE Internet Setup v1</a></li>
                                                 </ul>
                                             </div>
                                         </li>


### PR DESCRIPTION
This moves the QDE Internet Setup doc out of the v1 sidebar dropdown,
and places it directly inside the QDE dropdown. The URL is also
adjusted because of the change of the filename from
`QuickDeploymentInternetSetup-v1.md` to
`QuickDeploymentInternetSetup.md`.