### PR TITLE
(layout) Remove Puppet Webinar from Homepage

### DIFF
--- a/chocolatey/Website/Views/Pages/Home.cshtml
+++ b/chocolatey/Website/Views/Pages/Home.cshtml
@@ -68,25 +68,18 @@
         <div class="container-fluid py-3 pb-sm-0 bg-light">
             <div class="text-center">
                 <h4 class="mb-0">WEBINAR</h4>
-                <h1 class="font-weight-bold d-none d-sm-block">The Business Value of Modernizing Your Windows Infrastructure<br />and Bringing Linux & Windows Teams Closer</h1>
-                <h3 class="font-weight-bold d-sm-none">The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer</h3>
-                <h5>
-                    <span class="mr-md-4 mb-1 mb-md-0 d-inline-block"><i class="fas fa-calendar"></i> Tuesday, 22 September 2020</span>
-                    <br class="d-md-none" />
-                    <span>
-                        <i class="fas fa-clock"></i> 3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern
-                    </span>
-                </h5>
+                <h1 class="font-weight-bold display-4 d-none d-sm-block">Chocolatey Deployments -<br />Easily Orchestrate Amazing Things!</h1>
+                <h2 class="font-weight-bold d-sm-none">Chocolatey Deployments -<br />Easily Orchestrate Amazing Things!</h2>
             </div>
             <div class="row divider-row align-items-center my-4">
                 <div class="col-sm-6 mb-3 mb-sm-0">
                     <div class="d-flex align-items-center">
                         <div class="mr-3 text-sm-right ml-sm-auto order-2">
-                            <h5 class="font-weight-bold text-primary mb-0">Nigel Kersten</h5>
-                            <p class="mb-0"><strong>Customer Success Team at Puppet</strong></p>
+                            <h5 class="font-weight-bold text-primary mb-0">Gary Ewan Park</h5>
+                            <p class="mb-0"><strong>Senior Software Engineer at Chocolatey</strong></p>
                         </div>
                         <div class="order-1 order-sm-2 mr-3 mr-sm-0">
-                            <img class="rounded shadow" width="60" src="@Url.Content("~/content/images/speakers/nigel-kersten.jpg")" alt="Nigel Kersten" title="Nigel Kersten" />
+                            <img class="rounded shadow" width="60" src="@Url.Content("~/content/images/speakers/gary-ewan-park.jpg")" alt="Gary Ewan Park" title="Gary Ewan Park" />
                         </div>
                     </div>
                 </div>
@@ -103,11 +96,11 @@
                 </div>
             </div>
             <p class="mx-auto text-sm-center" style="max-width: 720px;">
-                Standardising tool sets across different Teams is not always easy... especially when different Teams have traditionally used different approaches and methodologies.
-                In this webinar we will unpack the advantages of a more standard, consistent approach with Puppet & Chocolatey.
+                Chocolatey Central Management now includes the premiere feature of managing endpoints through a Chocolatey-centered solution aka Deployments. We are excited to share what Deployments is all about!
             </p>
             <div class="text-center">
-                <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" target="_blank" rel="noreferrer" class="btn btn-success btn-lg mb-2"><span class="h2 font-weight-bold">Register Now</span></a>
+                <a href="https://chocolatey.zoom.us/webinar/register/WN_MPT5b34zQnud8R0nGgpe5A" target="_blank" rel="noreferrer" class="btn btn-success btn-lg mb-2"><span class="h2 font-weight-bold">Watch On-Demand Now</span></a>
+                <p class="mb-0"><a href="@Url.RouteUrl(RouteName.BlogArticle, new { articleName = "announcing-deployments" })">Read The Blog</a> | <a href="@Url.RouteUrl(RouteName.Events, new { eventName = "chocolatey-deployments" })">Learn More<span class="fas fa-angle-right"></span></a></p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Note: To be merged once the Puppet Webinar is over

Removes the Puppet webinar information from the homepage, as the event
date has passed and the replay is not available yet. This
replaces that information with the on-demand information for the
Deployments Webinar.