### PR TITLE
(GH-973) Prevent Form URL from Returning /policies

### DIFF
--- a/chocolatey/Website/App_Start/Routes.cs
+++ b/chocolatey/Website/App_Start/Routes.cs
@@ -386,7 +386,12 @@ namespace NuGetGallery
 
             routes.Add(new JsonRoute("json/{controller}"));
 
-            routes.MapRoute(RouteName.Policies, "policies/{action}", MVC.Pages.Terms());
+            routes.MapRouteSeo(
+               RouteName.Policies, "policies", new
+               {
+                   controller = "Pages",
+                   Action = "Terms"
+               });
 
             var packageListRoute = routes.MapRoute(RouteName.ListPackages, "packages", MVC.Packages.ListPackages());
 

--- a/chocolatey/Website/Controllers/PagesController.cs
+++ b/chocolatey/Website/Controllers/PagesController.cs
@@ -398,7 +398,7 @@ Machines: {5}
 
             //Find out if the user is part of a pipeline by examining the current URL query string
             var pipeline = true;
-            if (Request.QueryString.ToString().Contains("pipline=false"))
+            if (Request.QueryString.ToString().Contains("pipeline=false"))
             {
                 pipeline = false;
             }


### PR DESCRIPTION
(GH-973) Prevent Form URL from Returning /policies

Whenever a form was submitted, the URL being sent in and returned
always contained `/policies/` in the URL. With this update, this no
longer happens, and the forms are sent in from the URL in which they
come from, and also returned as such.

This bug was introduced in commit https://github.com/chocolatey/chocolatey.org/commit/9abd30456915145653706c7daf34aa2c9e1ba2a5 and happened whenever a form was references like:

`@using (Html.BeginForm("ContactSales", "Pages", FormMethod.Post, new { id = "i-recaptcha" }))`

Fixes #973