### PR TITLE
(maint) Update Puppet Webinar On-Demand Link

### DIFF
--- a/chocolatey/Website/Views/Events/Files/01-04-TheBusinessValueOfModernizingYourWindowsInfrastructure.md
+++ b/chocolatey/Website/Views/Events/Files/01-04-TheBusinessValueOfModernizingYourWindowsInfrastructure.md
@@ -6,9 +6,9 @@ Duration: 1 hour
 Title: The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer
 Speakers: Rob Reynolds, Nigel Kersten
 Image: <img class="lazy img-fluid" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-src="/content/images/events/01-04.jpg" alt="The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer" title="The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer" />
-RegisterLink: https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/
+RegisterLink: https://puppet.com/resources/webinar/the-business-value-of-modernizing-your-windows-infrastructure-and-bringing-linux-windows
 Tags: 2020, puppet, linux, infrastructure
 Summary: Standardising tool sets across different Teams is not always easy... especially when different Teams have traditionally used different approaches and methodologies. In this webinar we will unpack the advantages of a more standard, consistent approach with Puppet & Chocolatey.
 IncludeRegisterPage: false
-IsOnDemand: false
+IsOnDemand: true
 ---


### PR DESCRIPTION
Updates the link to the Puppet Webinar so users can watch on-demand.