### PR TITLE
(GH-970) Include a security.txt file

### DIFF
--- a/chocolatey/Website/.well-known/security.txt
+++ b/chocolatey/Website/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:security@chocolatey.io
+Preferred-Languages: en
+Canonical: https://chocolatey.org/.well-known/security.txt
+Policy: https://chocolatey.org/security

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -337,6 +337,14 @@
         <add name="X-Frame-Options" value="deny" />
       </customHeaders>
     </httpProtocol>
+    <rewrite>
+      <rules>
+        <rule name="Redirect security.txt">
+          <match url="^security.txt$" />
+          <action type="Redirect" url="/.well-known/security.txt" />
+        </rule>
+      </rules>
+    </rewrite>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1043,6 +1043,7 @@
     <EmbeddedResource Include="..\..\nugetgallery\Website\Infrastructure\Elmah.SqlServer.sql">
       <Link>Infrastructure\Elmah.SqlServer.sql</Link>
     </EmbeddedResource>
+    <Content Include=".well-known\security.txt" />
     <Content Include="7za.exe" />
     <Content Include="apple-touch-icon-114x114.png" />
     <Content Include="apple-touch-icon-120x120.png" />


### PR DESCRIPTION
Includes a security.txt file for users to better understand the best
way to report vulnerabilities.

The url chocolatey.org/security.txt will redirect to
chocolatey.org/.well-known/security.txt

Fixes #970 