### PR TITLE
(maint) Update Puppet Webinar Link in Sidebar

### DIFF
--- a/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
+++ b/chocolatey/Website/Views/Pages/_CollapsingRightSidebarContent.cshtml
@@ -38,15 +38,15 @@
 <hr />
 <div class="shuffle">
     <div class="text-center">
-        <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" rel="noreferrer" target="_blank">
+        <a href="https://puppet.com/resources/webinar/the-business-value-of-modernizing-your-windows-infrastructure-and-bringing-linux-windows" rel="noreferrer" target="_blank">
             <img class="img-fluid mb-3" src="@Url.Content("~/content/images/events/01-04.jpg")" alt="The Business Value of Modernizing Your Windows Infrastructure and Bringing Linux & Windows Teams Closer" />
         </a>
-        <p><strong>Tuesday, 22 September 2020<br />3 PM BST/GMT+1 / 4 PM CEST / 9 AM Central / 10 AM Eastern</strong></p>
+        <p><strong>Webinar Replay from<br />Tuesday, 22 September 2020</strong></p>
         <p class="text-left">
             Standardising tool sets across different Teams is not always easy... especially when different Teams have traditionally used different approaches and methodologies.
             In this webinar we will unpack the advantages of a more standard, consistent approach with Puppet & Chocolatey.
         </p>
-        <a href="https://puppet.com/events/the-business-value-of-modernizing-your-windows-infrastructure/" rel="noreferrer" target="_blank" class="btn btn-primary">Register Now</a>
+        <a href="https://puppet.com/resources/webinar/the-business-value-of-modernizing-your-windows-infrastructure-and-bringing-linux-windows" rel="noreferrer" target="_blank" class="btn btn-primary">Watch Now</a>
         <hr />
     </div>
     <div class="text-center">


### PR DESCRIPTION
Updates the link to the on-demand replay of the Puppet webinar that
is found in the right side announcement bar.