### PR TITLE
(GH-1000) Make Cookie Work Across All Domains

### DIFF
--- a/chocolatey/Website/Content/scss/_alerts.scss
+++ b/chocolatey/Website/Content/scss/_alerts.scss
@@ -1,0 +1,71 @@
+#cookieNoticeAlert {
+    z-index: 99999;
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+}
+
+@each $color, $value in $theme-colors {
+    .alert-#{$color} {
+        color: color-yiq($value);
+
+        a {
+            color: color-yiq($value);
+            font-weight: bold;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+}
+
+.alert-dismissible-center {
+    display: block;
+    text-align: center;
+    font-size: $small-font-size;
+    padding: .5rem 2.5rem .5rem 15px;
+
+    &.alert-btn-center {
+        padding: 0.5rem 15px;
+    }
+
+    .close {
+        padding: .42rem 15px;
+    }
+
+    .btn {
+        margin-top: $spacer !important;
+        width: 100%;
+    }
+}
+
+@include media-breakpoint-up(sm) {
+    .alert-dismissible-center {
+        padding: 0.5rem 15px;
+
+        .btn {
+            width: 50%;
+        }
+    }
+}
+
+@include media-breakpoint-up(md) {
+    .alert-dismissible-center {
+        text-align: center;
+        font-size: $font-size-base;
+        display: flex;
+        align-content: center;
+        justify-content: center;
+
+        .close {
+            padding: .55rem 15px;
+        }
+
+        .btn {
+            width: auto;
+            margin-top: 0 !important;
+            margin-left: $spacer;
+        }
+    }
+}

--- a/chocolatey/Website/Content/scss/_base.scss
+++ b/chocolatey/Website/Content/scss/_base.scss
@@ -140,30 +140,6 @@ footer.bg-medium-dark a:hover, #editions ul li a:hover, .sticky-nav a.active {
     color: $primary;
 }
 
-/*Alerts and Cookies Notifications*/
-.alert {
-    z-index: 2;
-}
-
-.alert-primary .alert-link {
-    color: $primary;
-    text-decoration: underline;
-}
-
-.alert-dismissible .close {
-    padding: 0;
-    right: 10px;
-    height: 100%;
-}
-
-.cookies-popup {
-    display: none;
-    position: fixed;
-    width: 100%;
-    bottom: 0;
-    z-index: 9999;
-}
-
 .gitter-chat-embed {
     z-index: 9999;
 }

--- a/chocolatey/Website/Content/scss/_chocolatey-variables.scss
+++ b/chocolatey/Website/Content/scss/_chocolatey-variables.scss
@@ -38,6 +38,10 @@ $card-border-width: 0;
 // Alerts
 $alert-border-radius: 0;
 $alert-border-width: 0;
+$alert-margin-bottom: 0;
+$alert-border-width: 0;
+$alert-bg-level: 0;
+$alert-color-level: 0;
 
 // Custom Select
 $custom-select-indicator: "";

--- a/chocolatey/Website/Content/scss/chocolatey.scss
+++ b/chocolatey/Website/Content/scss/chocolatey.scss
@@ -14,6 +14,7 @@
 @import "Content/scss/base";
 @import "Content/scss/search";
 @import "Content/scss/navigation";
+@import "Content/scss/alerts";
 @import "Content/scss/backgrounds";
 @import "Content/scss/callouts";
 @import "Content/scss/testimonials";

--- a/chocolatey/Website/Scripts/custom.js
+++ b/chocolatey/Website/Scripts/custom.js
@@ -9,34 +9,45 @@ $(window).on('load', function () {
 // Show modal on tempdata "message"
 $('#tempdata-message').modal('show');
 
-// Cookies Notice
-var CookiesNotice = (function () {
-    return {
-        modal: function (cookieName) {
-            $(".cookies-popup .cookies-close").click(function (e) {
-                $(e.target).closest(".cookies-popup").hide();
-                var d = new Date();
-                // 100 years in milliseconds: 100 years * 365 days * 24 hours * 60 minutes * 60 seconds * 1000ms
-                d.setTime(d.getTime() + (100 * 365 * 24 * 60 * 60 * 1000));
-                var expires = "expires=" + d.toUTCString();
-                document.cookie = cookieName + "=true;" + expires + ";path=/";
-            });
-        }
+// Cookie Notice
+var cookieNoticeAlert = $('#cookieNoticeAlert'),
+    cookieNoticeName = 'chocolatey_hide_cookies_notice',
+    cookieNotice = getCookie(cookieNoticeName);
+
+if (cookieNotice) {
+    cookieNoticeAlert.remove();
+} else {
+    cookieNoticeAlert.removeClass('d-none');
+}
+
+cookieNoticeAlert.find('button').click(function () {
+    console.log(getCookieExpirationNever());
+    if (~location.hostname.indexOf('chocolatey.org')) {
+        document.cookie = cookieNoticeName + '=true; ' + getCookieExpirationNever() + 'path=/; domain=chocolatey.org;';
+    } else {
+        document.cookie = cookieNoticeName + '=true;' + getCookieExpirationNever() + 'path=/;';
     }
-})();
-CookiesNotice.modal("chocolatey_hide_cookies_notice");
-if (!getCookie('chocolatey_hide_cookies_notice')) {
-    $(".cookies-popup").css('display', 'block');
+});
+function getCookieExpirationNever() {
+    var d = new Date();
+    // 100 years in milliseconds: 100 years * 365 days * 24 hours * 60 minutes * 60 seconds * 1000ms
+    d.setTime(d.getTime() + (100 * 365 * 24 * 60 * 60 * 1000));
+    return 'expires=' + d.toUTCString() + ';';
 }
 
 // Top Navigation
 $(document).ready(function () {
-    // Top Alert
-    var notice = window.sessionStorage.getItem('notice');
-    if (!notice && !$(".notice-text").hasClass('d-none')) {
-        $('.notice-text').show();
+    // Top notice alert
+    var topNoticeAlert = $('#topNoticeAlert'),
+        topNotice = window.sessionStorage.getItem('notice');
+
+    if (topNotice) {
+        topNoticeAlert.remove();
+    } else {
+        topNoticeAlert.removeClass('d-none');
     }
-    $('.notice-text button').click(function () {
+
+    topNoticeAlert.find('button').click(function () {
         sessionStorage.setItem('notice', 'true');
     });
 

--- a/chocolatey/Website/Views/Shared/_AlertTop.cshtml
+++ b/chocolatey/Website/Views/Shared/_AlertTop.cshtml
@@ -1,10 +1,13 @@
 ﻿@{
-    var noticeText = ("<a href='/covid-19'><u>Here's how we're responding to COVID-19 plus resources to help</u></a>");
+    var noticeText = "<a href='/covid-19'>Here's how we're responding to COVID-19 plus resources to help</a>";
 }
 
-<div class="alert bg-danger text-white alert-dismissible fade show mb-0 text-center p-2 notice-text @if (string.IsNullOrEmpty(noticeText)) { <text> d-none</text> }" role="alert" aria-atomic="true" style="display: none;">
-    <p class="mb-0 mr-3 mr-md-0"><strong>@Html.Raw(noticeText)</strong></p>
-    <button type="button" class="close py-0" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-    </button>
-</div>
+@if (!string.IsNullOrEmpty(noticeText))
+{
+    <div id="topNoticeAlert" class="alert alert-danger alert-dismissible alert-dismissible-center fade show d-none" role="alert">
+        <p class="mb-0">@Html.Raw(noticeText)</p>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+}

--- a/chocolatey/Website/Views/Shared/_CookiePolicy.cshtml
+++ b/chocolatey/Website/Views/Shared/_CookiePolicy.cshtml
@@ -1,9 +1,5 @@
-﻿<div class="cookies-popup alert bg-primary alert-dismissible fade show text-center mb-0 p-2 border-top" role="alert" aria-atomic="true">
-    <strong>Chocolatey.org uses cookies to enhance the user experience of the site.</strong>
-    <button type="button" class="btn btn-light btn-sm cookies-close d-none d-sm-inline-block" data-dismiss="alert" aria-label="Close">
-        I accept
-    </button>
-    <button type="button" class="btn btn-light cookies-close d-sm-none" data-dismiss="alert" aria-label="Close">
-        I accept
-    </button>
+﻿<div id="cookieNoticeAlert" class="alert alert-primary alert-dismissible alert-dismissible-center alert-btn-center fade show d-none" role="alert">
+    <p class="mb-0"><strong>chocolatey.org uses cookies to enhance the user experience of the site.</strong></p>
+    <button type="button" class="btn btn-light btn-sm d-none d-md-inline-block" data-dismiss="alert" aria-label="Close">I accept</button>
+    <button type="button" class="btn btn-light d-md-none" data-dismiss="alert" aria-label="Close">I accept</button>
 </div>

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1460,6 +1460,7 @@
     <Content Include="Content\scss\_ribbons.scss" />
     <Content Include="Content\scss\_countdown.scss" />
     <Content Include="Content\scss\_collapsing-sidebar.scss" />
+    <Content Include="Content\scss\_alerts.scss" />
     <None Include="optipng.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
The cookie set by the cookie banner notice has been set to have the
domain of chocolatey.org. This will allow the cookie to be read and
used on the main chocolatey.org and any subdomain.

If the cookie is set on a local environment, it will not be set with
this property. This has been done so that the cookie still works and
can be tested while running locally. The cross domain
functionality will only work on the actual live site.

This also slightly enhances the styling and uses a consistent format
that will be used across subdomains visually.

Fixes #1000 