### PR TITLE
(GH-1006) Update Google Analytics Snippet

### DIFF
--- a/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
+++ b/chocolatey/Website/Views/Shared/_BaseLayout.cshtml
@@ -63,7 +63,13 @@
     }
     @if (propertyId != null)
     {
-        @Analytics.GetGoogleHtml(propertyId)
+        <script async src="https://www.googletagmanager.com/gtag/js?id=@propertyId"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '@propertyId');
+        </script>
     }
     @RenderSection("TopScripts", required: false)
 </head>


### PR DESCRIPTION
Updates the Google Analytics snippet to the recommended usage provided
by Google. The previous implementation was using a legacy helper to
generate an outdated snippet.

https://docs.microsoft.com/en-us/previous-versions/gg547914(v=vs.99)

Fixes #1006