### PR TITLE
(maint) Fix Typo in Speaker Name

### DIFF
--- a/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
+++ b/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
@@ -254,7 +254,7 @@
                                 <p class="mb-0">
                                     <span class="badge badge-pill text-right text-capitalize badge-secondary d-inline-block mb-2 mb-md-0 mr-md-3">Livestream</span>
                                     <br class="d-md-none" />
-                                    <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Stephen Valdinger, Joel (Swallow) Francis</span>
+                                    <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Stephen Valdinger, Joel (Sallow) Francis</span>
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Corrects a typo in a speakers name on the new 12 Days of Chocolatey
page.