### PR TITLE
(maint) Adjust Wording on 12 Days Page

### DIFF
--- a/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
+++ b/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
@@ -37,7 +37,7 @@
                     @*<a href="@post.RegisterLink" target="_blank" rel="noreferrer" class="btn btn-success btn-lg mb-4 mb-md-5"><span class="h2 font-weight-bold">Reserve My Spot Now</span></a>*@
                     <button class="btn btn-secondary btn-lg mb-3" disabled><span class="h2 font-weight-bold">Reserve My Spot Now</span></button>
                     <p style="max-width: 720px;" class="mb-4 mb-md-5 mx-auto">
-                        Prizes for first 50 registrants! Registration opens on Tuesday at 12:30 PM CST during the live stream announcement. We'll update this page after on Tuesday Nov 24th. Join the live stream at 
+                        Prizes for first 50 registrants! Registration opens on Tuesday at 12:30 PM CST during the livestream announcement. We'll update this page on Tuesday Nov 24th after the livestream. Join the livestream at 
                         <a class="btn btn-link text-success p-0" href="https://twitch.tv/chocolateysoftware">https://twitch.tv/chocolateysoftware</a> on Tuesday at 12:25 PM CST. <br class="d-none d-lg-block" />
                         <a class="btn btn-link p-0 text-success" href="https://everytimezone.com/s/37875715" target="_blank" rel="noreferrer">Convert to your time zone<i class="fas fa-angle-right"></i></a>
                     </p>
@@ -60,7 +60,7 @@
                             @Html.Partial("~/Views/Shared/_LivestreamShare.cshtml")
                         </div>
                         <ul class="list-circle list-circle-success-fade list-circle-fa-check">
-                            <li>Live streamed on all your favorite platforms</li>
+                            <li>Livestreamed on all your favorite platforms</li>
                             <li>One hour each day <a href="#schedule" rel="nofollow">(see schedule below)</a></li>
                             <li>Chocolatey Central Management Deployments</li>
                             <li>Chocolatey &amp; Ansible</li>
@@ -68,7 +68,7 @@
                             <li>Self-Service Anywhere</li>
                             <li>NEW exciting Chocolatey announcements</li>
                         </ul>
-                        <p>Can't attend live? We'll try to record for later, but you'll miss out on being able to contribute and shape the discussions during the live stream sessions! Plus you'll miss out on giveaways!</p>
+                        <p>Can't attend live? We'll try to record for later, but you'll miss out on being able to contribute and shape the discussions during the livestream sessions! Plus you'll miss out on giveaways!</p>
                         @*<div class="text-center d-md-none"><a href="@post.RegisterLink" target="_blank" rel="noreferrer" class="btn btn-lg btn-success">Reserve My Spot Now</a></div>*@
                     </div>
                     <div class="col-lg-6 d-none d-md-block">


### PR DESCRIPTION
Updates "live stream" to "livestream" and makes the text in the header
a little more clear and readable on the 12 Days of Chocolatey event page.
