### PR TITLE
(events) Add an "Add to Calendar" Button

### DIFF
--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-01December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-01December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032653Z
+UID:20201126T032653Z-1909760644@marudot.com
+DTSTART;TZID=Europe/London:20201201T160000
+DTEND;TZID=Europe/London:20201201T170000
+SUMMARY:12 Days of Chocolatey - "The Power of Simple" Keynote - Rob Reynolds
+DESCRIPTION:Join the Chocolatey team for Day 1 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "The Power of Simple" Keynote - Rob Reynolds\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "The Power of Simple" Keynote - Rob Reynolds
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-02December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-02December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032753Z
+UID:20201126T032753Z-1578312904@marudot.com
+DTSTART;TZID=Europe/London:20201202T160000
+DTEND;TZID=Europe/London:20201202T170000
+SUMMARY:12 Days of Chocolatey - "Redefining Chocolatey" - Rob Reynolds\, Adil Leghari
+DESCRIPTION:Join the Chocolatey team for Day 2 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Redefining Chocolatey" - Rob Reynolds\, Adil Leghari\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Redefining Chocolatey" - Rob Reynolds, Adil Leghari
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-04December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-04December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032821Z
+UID:20201126T032821Z-1322802828@marudot.com
+DTSTART;TZID=Europe/London:20201204T160000
+DTEND;TZID=Europe/London:20201204T170000
+SUMMARY:12 Days of Chocolatey - "Chocolatey in the Organizations" - Gary Ewan Park
+DESCRIPTION:Join the Chocolatey team for Day 4 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Chocolatey in the Organizations" - Gary Ewan Park\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Chocolatey in the Organizations" - Gary Ewan Park
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-07December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-07December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032849Z
+UID:20201126T032849Z-102160163@marudot.com
+DTSTART;TZID=Europe/London:20201207T160000
+DTEND;TZID=Europe/London:20201207T170000
+SUMMARY:12 Days of Chocolatey - "Building Packages (Open Source and C4B)" - Adil Leghari
+DESCRIPTION:Join the Chocolatey team for Day 5 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Building Packages (Open Source and C4B)" - Adil Leghari\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Building Packages (Open Source and C4B)" - Adil Leghari
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-08December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-08December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032912Z
+UID:20201126T032912Z-2101916732@marudot.com
+DTSTART;TZID=Europe/London:20201208T160000
+DTEND;TZID=Europe/London:20201208T170000
+SUMMARY:12 Days of Chocolatey - "Exploring Quick Deployment Environment (QDE) & Offline / Internal Environments" - Stephen Valdinger
+DESCRIPTION:Join the Chocolatey team for Day 6 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Exploring Quick Deployment Environment (QDE) & Offline / Internal Environments" - Stephen Valdinger\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Exploring Quick Deployment Environment (QDE) & Offline / Internal Environments" - Stephen Valdinger
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-09December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-09December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T032943Z
+UID:20201126T032943Z-1420330490@marudot.com
+DTSTART;TZID=Europe/London:20201209T160000
+DTEND;TZID=Europe/London:20201209T170000
+SUMMARY:12 Days of Chocolatey - "Choco CCM Module (Deployments / Integrations / Reporting)" - Stephen Valdinger\, Joel (Sallow) Francis
+DESCRIPTION:Join the Chocolatey team for Day 7 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Choco CCM Module (Deployments / Integrations / Reporting)" - Stephen Valdinger\, Joel (Sallow) Francis\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Choco CCM Module (Deployments / Integrations / Reporting)" - Stephen Valdinger, Joel (Sallow) Francis
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-11December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-11December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T033007Z
+UID:20201126T033007Z-207369122@marudot.com
+DTSTART;TZID=Europe/London:20201211T160000
+DTEND;TZID=Europe/London:20201211T170000
+SUMMARY:12 Days of Chocolatey - "Chocolatey Integrations Discussion (including SCCM & Intune)" - Chocolatey Team
+DESCRIPTION:Join the Chocolatey team for Day 9 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Chocolatey Integrations Discussion (including SCCM & Intune)" - Chocolatey Team\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Chocolatey Integrations Discussion (including SCCM & Intune)" - Chocolatey Team
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-14December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-14December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T033031Z
+UID:20201126T033031Z-1055364870@marudot.com
+DTSTART;TZID=Europe/London:20201214T160000
+DTEND;TZID=Europe/London:20201214T170000
+SUMMARY:12 Days of Chocolatey - "Exploring Self-Service Anywhere" - Paul Broadwith
+DESCRIPTION:Join the Chocolatey team for Day 10 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Exploring Self-Service Anywhere" - Paul Broadwith\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Exploring Self-Service Anywhere" - Paul Broadwith
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-15December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-15December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T033102Z
+UID:20201126T033102Z-253513911@marudot.com
+DTSTART;TZID=Europe/London:20201215T160000
+DTEND;TZID=Europe/London:20201215T170000
+SUMMARY:12 Days of Chocolatey - "Exciting Developments to Share" - Rob Reynolds\, Stephen Valdinger
+DESCRIPTION:Join the Chocolatey team for Day 11 of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Exciting Developments to Share" - Rob Reynolds\, Stephen Valdinger\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Exciting Developments to Share" - Rob Reynolds, Stephen Valdinger
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Content/calendars/12DaysOfChocolatey-16December2020.ics
+++ b/chocolatey/Website/Content/calendars/12DaysOfChocolatey-16December2020.ics
@@ -1,0 +1,38 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ical.marudot.com//iCal Event Maker
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/London
+TZURL:http://tzurl.org/zoneinfo-outlook/Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:BST
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20201126T033127Z
+UID:20201126T033127Z-1090373476@marudot.com
+DTSTART;TZID=Europe/London:20201216T160000
+DTEND;TZID=Europe/London:20201216T170000
+SUMMARY:12 Days of Chocolatey - "Q&A Panel Session & Wrap" - Chocolatey Team
+DESCRIPTION:Join the Chocolatey team for the final day of The 12 Days of Chocolatey!\n\nTopic: 12 Days of Chocolatey - "Q&A Panel Session & Wrap" - Chocolatey Team\n\nJoin Chocolatey live on:\nTwitch: https://www.twitch.tv/chocolateysoftware\nYouTube: https://www.youtube.com/chocolateysoftware\nTwitter: https://twitter.com/chocolateynuget\nFacebook: https://www.facebook.com/ChocolateySoftware
+LOCATION:Livestream - See description for details
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:12 Days of Chocolatey - "Q&A Panel Session & Wrap" - Chocolatey Team
+TRIGGER:-PT30M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
+++ b/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
@@ -137,6 +137,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speaker: Rob Reynolds</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar1">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22The%20Power%20of%20Simple%22%20Keynote%20-%20Rob%20Reynolds&amp;dates=20201201T160000Z/20201201T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%201%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22The%20Power%20of%20Simple%22%20Keynote%20-%20Rob%20Reynolds%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22The%20Power%20of%20Simple%22%20Keynote%20-%20Rob%20Reynolds&amp;st=20201201T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%201%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22The%20Power%20of%20Simple%22%20Keynote%20-%20Rob%20Reynolds%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-01December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-01December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -155,6 +164,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Rob Reynolds, Adil Leghari</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar2">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Redefining%20Chocolatey%22%20-%20Rob%20Reynolds,%20Adil%20Leghari&amp;dates=20201202T160000Z/20201202T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%202%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Redefining%20Chocolatey%22%20-%20Rob%20Reynolds,%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Redefining%20Chocolatey%22%20-%20Rob%20Reynolds,%20Adil%20Leghari&amp;st=20201202T100000Z&amp;dur=0-2300&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%202%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Redefining%20Chocolatey%22%20-%20Rob%20Reynolds,%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-02December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-02December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -177,7 +195,7 @@
                                     Chocolatey Central Management's premiere feature of Deployments now can work with schedules, semi-connected environments, and CCM (Chocolatey Central Management) overall has a published API so you can accomplish more, much more.
                                     <strong> Separate Registration Required!</strong>
                                 </p>
-                                <a class="btn btn-outline-secondary" target="_blank" href="https://chocolatey.zoom.us/webinar/register/6516058272049/WN__AtcpeIbQnGACco6PE2QbA">Register Now</a>
+                                <a class="btn btn-outline-success" target="_blank" href="https://chocolatey.zoom.us/webinar/register/6516058272049/WN__AtcpeIbQnGACco6PE2QbA">Register Now</a>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -196,6 +214,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Gary Ewan Park</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar4">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park&amp;dates=20201204T160000Z/20201204T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%204%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park&amp;st=20201204T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%204%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-04December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-04December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -214,6 +241,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Adil Leghari</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar5" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar5">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari&amp;dates=20201207T160000Z/20201207T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%205%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari&amp;st=20201207T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%205%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-07December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-07December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -232,6 +268,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Stephen Valdinger</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar6">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Exploring%20Quick%20Deployment%20Environment%20(QDE)%20%26%20Offline%20/%20Internal%20Environments%22%20-%20Stephen%20Valdinger&amp;dates=20201208T160000Z/20201208T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%206%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exploring%20Quick%20Deployment%20Environment%20(QDE)%20%26%20Offline%20/%20Internal%20Environments%22%20-%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Exploring%20Quick%20Deployment%20Environment%20(QDE)%20%26%20Offline%20/%20Internal%20Environments%22%20-%20Stephen%20Valdinger&amp;st=20201208T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%206%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exploring%20Quick%20Deployment%20Environment%20(QDE)%20%26%20Offline%20/%20Internal%20Environments%22%20-%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-08December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-08December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -250,6 +295,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Stephen Valdinger, Joel (Sallow) Francis</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar7" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar7">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Choco%20CCM%20Module%20(Deployments%20/%20Integrations%20/%20Reporting)%22%20-%20Stephen%20Valdinger,%20Joel%20(Sallow)%20Francis&amp;dates=20201209T160000Z/20201209T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%207%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Choco%20CCM%20Module%20(Deployments%20/%20Integrations%20/%20Reporting)%22%20-%20Stephen%20Valdinger,%20Joel%20(Sallow)%20Francis%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Choco%20CCM%20Module%20(Deployments%20/%20Integrations%20/%20Reporting)%22%20-%20Stephen%20Valdinger,%20Joel%20(Sallow)%20Francis&amp;st=20201209T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%207%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Choco%20CCM%20Module%20(Deployments%20/%20Integrations%20/%20Reporting)%22%20-%20Stephen%20Valdinger,%20Joel%20(Sallow)%20Francis%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-09December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-09December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -272,7 +326,7 @@
                                     Together, Ansible and Chocolatey bring faster and more secure deployments to your Windows environments. Use Chocolatey for software/package management and Ansible to automate and guarantee the desired state of your Windows infrastructure, 
                                     allowing your team to securely deploy applications faster than ever. <strong>Separate Registration Required!</strong>
                                 </p>
-                                <a class="btn btn-outline-secondary" target="_blank" href="https://chocolatey.zoom.us/webinar/register/9116058944622/WN_4sBxu-fqRRSL3-fglGqclQ">Register Now</a>
+                                <a class="btn btn-outline-success" target="_blank" href="https://chocolatey.zoom.us/webinar/register/9116058944622/WN_4sBxu-fqRRSL3-fglGqclQ">Register Now</a>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -291,6 +345,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Chocolatey Team</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar9" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar9">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20Integrations%20Discussion%20(including%20SCCM%20%26%20Intune)%22%20-%20Chocolatey%20Team&amp;dates=20201211T160000Z/20201211T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%209%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20Integrations%20Discussion%20(including%20SCCM%20%26%20Intune)%22%20-%20Chocolatey%20Team%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20Integrations%20Discussion%20(including%20SCCM%20%26%20Intune)%22%20-%20Chocolatey%20Team&amp;st=20201211T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%209%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20Integrations%20Discussion%20(including%20SCCM%20%26%20Intune)%22%20-%20Chocolatey%20Team%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-11December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-11December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -309,6 +372,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Paul Broadwith</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar10">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Exploring%20Self-Service%20Anywhere%22%20-%20Paul%20Broadwith&amp;dates=20201214T160000Z/20201214T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%2010%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exploring%20Self-Service%20Anywhere%22%20-%20Paul%20Broadwith%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Exploring%20Self-Service%20Anywhere%22%20-%20Paul%20Broadwith&amp;st=20201214T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%2010%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exploring%20Self-Service%20Anywhere%22%20-%20Paul%20Broadwith%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-14December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-14December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -327,6 +399,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Rob Reynolds, Stephen Valdinger</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar11" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar11">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Will%20be%20announced%20soon%20(and%20will%20be%20exciting!)%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger&amp;dates=20201215T160000Z/20201215T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%2011%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Will%20be%20announced%20soon%20(and%20will%20be%20exciting!)%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Will%20be%20announced%20soon%20(and%20will%20be%20exciting!)%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger&amp;st=20201215T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%2011%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Will%20be%20announced%20soon%20(and%20will%20be%20exciting!)%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-15December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-15December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -345,6 +426,15 @@
                                     <br class="d-md-none" />
                                     <span><i class="fas fa-microphone text-secondary mr-1"></i>Speakers: Chocolatey Team</span>
                                 </p>
+                                <button class="btn btn-outline-success dropdown-toggle mt-3" type="button" id="addToCalendar12" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
+                                </button>
+                                <div class="dropdown-menu" aria-labelledby="addToCalendar12">
+                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Exciting%20Developments%20to%20Share%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger&amp;dates=20201215T160000Z/20201215T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%2011%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exciting%20Developments%20to%20Share%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
+                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Exciting%20Developments%20to%20Share%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger&amp;st=20201215T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%2011%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Exciting%20Developments%20to%20Share%22%20-%20Rob%20Reynolds,%20Stephen%20Valdinger%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-16December2020.ics")" download>iCal Calendar</a>
+                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-16December2020.ics")" download>Outlook Calendar</a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1473,6 +1473,16 @@
     <Content Include="Content\scss\_countdown.scss" />
     <Content Include="Content\scss\_collapsing-sidebar.scss" />
     <Content Include="Content\scss\_alerts.scss" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-01December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-02December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-04December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-07December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-08December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-09December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-11December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-14December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-15December2020.ics" />
+    <Content Include="Content\calendars\12DaysOfChocolatey-16December2020.ics" />
     <None Include="optipng.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Adds an "Add to Calendar" button to the 12 Days of Chocolatey event
page under each event. Calendars are included for Google, Yahoo, iCal,
and Outlook.