### PR TITLE
(events) Update streaming platforms and add replays

### DIFF
--- a/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
+++ b/chocolatey/Website/Views/Events/12DaysOfChocolatey.cshtml
@@ -209,15 +209,7 @@
                                     Come discover the best practices for setting up and configuring Chocolatey in an Organization. We’ll show you how to better leverage the Chocolatey Community Repository for packages updates,
                                     as well as take advantage of the new functionality offered in Chocolatey for Business.
                                 </p>
-                                <button class="btn btn-outline-success dropdown-toggle" type="button" id="addToCalendar4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
-                                </button>
-                                <div class="dropdown-menu" aria-labelledby="addToCalendar4">
-                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park&amp;dates=20201204T160000Z/20201204T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%204%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
-                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park&amp;st=20201204T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%204%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Chocolatey%20in%20the%20Organizations%22%20-%20Gary%20Ewan%20Park%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
-                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-04December2020.ics")" download>iCal Calendar</a>
-                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-04December2020.ics")" download>Outlook Calendar</a>
-                                </div>
+                                <a class="btn btn-link text-dark font-weight-bold btn-replay" target="_blank" href="https://youtu.be/3itZw3PSmmw?t=467"><i class="fab fa-youtube bg-youtube"></i> Watch the Replay</a>
                             </div>
                         </div>
                         <hr class="my-4" />
@@ -241,15 +233,7 @@
                                     Building Chocolatey packages from scratch can take time and effort. We’ll show you some tips and tricks to help get you started,
                                     and then show off the “Easy Button” with Package Builder (a Chocolatey for Business feature).
                                 </p>
-                                <button class="btn btn-outline-success dropdown-toggle" type="button" id="addToCalendar5" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <i class="fas fa-calendar-plus mr-2"></i>Add to Calendar
-                                </button>
-                                <div class="dropdown-menu" aria-labelledby="addToCalendar5">
-                                    <a class="dropdown-item" target="_blank" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=12%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari&amp;dates=20201207T160000Z/20201207T170000Z&amp;details=Join%20the%20Chocolatey%20team%20for%20Day%205%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;location=Livestream%20-%20See%20description%20for%20links&amp;sprop=&amp;sprop=name:">Google Calendar</a>
-                                    <a class="dropdown-item" target="_blank" href="http://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title=12%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari&amp;st=20201207T100000Z&amp;dur=0100&amp;desc=Join%20the%20Chocolatey%20team%20for%20Day%205%20of%20The%2012%20Days%20of%20Chocolatey!%0A%0ATopic:%2012%20Days%20of%20Chocolatey%20-%20%22Building%20Packages%20(Open%20Source%20and%20C4B)%22%20-%20Adil%20Leghari%0A%0AJoin%20Chocolatey%20live%20on:%0ATwitch:%20https://www.twitch.tv/chocolateysoftware%0AYouTube:%20https://www.youtube.com/chocolateysoftware%0ATwitter:%20https://twitter.com/chocolateynuget%0AFacebook:%20https://www.facebook.com/ChocolateySoftware&amp;in_loc=Livestream%20-%20See%20description%20for%20links">Yahoo Calendar</a>
-                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-07December2020.ics")" download>iCal Calendar</a>
-                                    <a class="dropdown-item" href="@Url.Content("~/content/calendars/12DaysOfChocolatey-07December2020.ics")" download>Outlook Calendar</a>
-                                </div>
+                                <a class="btn btn-link text-dark font-weight-bold btn-replay" target="_blank" href="https://youtu.be/9r-IIU1fD8U?t=469"><i class="fab fa-youtube bg-youtube"></i> Watch the Replay</a>
                             </div>
                         </div>
                         <hr class="my-4" />

--- a/chocolatey/Website/Views/Shared/_LivestreamShare.cshtml
+++ b/chocolatey/Website/Views/Shared/_LivestreamShare.cshtml
@@ -12,12 +12,6 @@
         </a>
     </li>
     <li class="list-inline-item">
-        <a class="bg-twitter" href="https://twitter.com/chocolateynuget" target="_blank" rel="noreferrer">
-            <i aria-hidden="true" class="fab fa-twitter mr-2 display-4"></i>
-            <span class="sr-only">Watch Chocolatey Software on Twitter</span>
-        </a>
-    </li>
-    <li class="list-inline-item">
         <a class="bg-facebook" href="https://facebook.com/ChocolateySoftware" target="_blank" rel="noreferrer">
             <i aria-hidden="true" class="fab fa-facebook display-4"></i>
             <span class="sr-only">Watch Chocolatey Software on Facebook</span>


### PR DESCRIPTION
In this PR:

* Removes Twitter as a streaming platform for The 12 Days of Chocolatey
* Adds replay links to expired events for The 12 Days of Chocolatey