### PR TITLE
(GH-1029) Remove Site Results Tab from Search

### DIFF
--- a/chocolatey/Website/Scripts/package-list/package-list.js
+++ b/chocolatey/Website/Scripts/package-list/package-list.js
@@ -50,14 +50,3 @@ $(function () {
         $(".modal-closeable").css('display', 'block');
     }
 });
-
-// Documentation Search Results
-(function () {
-    var cx = '013536524443644524775:xv95wv156yw';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-})();

--- a/chocolatey/Website/Views/Packages/ListPackages.cshtml
+++ b/chocolatey/Website/Views/Packages/ListPackages.cshtml
@@ -53,220 +53,194 @@
                 </div>
                 @Html.Partial("~/Views/Packages/_CommunityInfoDisclaimer.cshtml")
             }
-            @if (!String.IsNullOrEmpty(Model.SearchTerm))
-            {
-                <ul class="nav nav-tabs mb-3" role="tablist">
-                    <li class="nav-item">
-                        <a class="nav-link active" id="packages-tab" data-toggle="tab" href="#packages-results" role="tab" aria-controls="packages-results" aria-selected="true">View Packages</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" id="documentation-tab" data-toggle="tab" href="#documentation-results" role="tab" aria-controls="documentation-results" aria-selected="false">View Site Results</a>
-                    </li>
-                </ul>
-            }
-            <div class="tab-content">
-                <div class="tab-pane fade show active" id="packages-results" role="tabpanel" aria-labelledby="packages-tab">
-                    <div class="d-lg-flex align-items-lg-center justify-content-lg-between">
-                        <div>
-                            @if (!String.IsNullOrEmpty(Model.SearchTerm) && !moderationQueue)
-                            {
-                                <h3 class="mb-0">Search for "@Model.SearchTerm" Returned @Model.TotalCount <text>Package</text>@if (Model.TotalCount != 1){<text>s</text>}</h3>
-                            }
-                            else
-                            {
-                                if (!moderationQueue)
-                                {
-                                    <h3 class="mb-0">
-                                        @if (Model.TotalCount == 1)
-                                        {<text>There is @Model.TotalCount Community Maintained Package</text>}
-                                        else
-                                        {<text>There are @Model.TotalCount Community Maintained Packages</text>}
-                                    </h3>
-                                }
+            <div class="d-lg-flex align-items-lg-center justify-content-lg-between">
+                <div>
+                    @if (!String.IsNullOrEmpty(Model.SearchTerm) && !moderationQueue)
+                    {
+                        <h3 class="mb-0">Search for "@Model.SearchTerm" Returned @Model.TotalCount <text>Package</text>@if (Model.TotalCount != 1){<text>s</text>}</h3>
+                    }
+                    else
+                    {
+                        if (!moderationQueue)
+                        {
+                            <h3 class="mb-0">
+                                @if (Model.TotalCount == 1)
+                                {<text>There is @Model.TotalCount Community Maintained Package</text>}
                                 else
-                                {
-                                    <h3 class="mb-0">
-                                        @{
-                                            var moderationStatus = @Model.ModerationStatus.Remove(@Model.ModerationStatus.IndexOf("-")); // Get everything after -status
-                                            moderationStatus = char.ToUpper(moderationStatus.First()) + moderationStatus.Substring(1).ToLower(); // Capitalize first letter
-                                        }
-                                        @if (!String.IsNullOrEmpty(Model.SearchTerm))
-                                        {
-                                            if (moderationStatus.Equals("All")){ moderationStatus = string.Empty; }
-                                            <text>Search for "@Model.SearchTerm" Returned @Model.TotalCount @moderationStatus Package</text>if(@Model.TotalCount != 1){<text>s</text>}
-                                        }
-                                        else if (moderationStatus.Equals("All")) {
-                                            if (@moderationCount == 1)
-                                            {<text>There is @moderationCount Package</text>}
-                                            else
-                                            {<text>There are @moderationCount Packages</text>}
-                                        }
-                                        else {
-                                            if (@Model.TotalCount == 1)
-                                            {<text>There is @Model.TotalCount @moderationStatus Package</text>}
-                                            else
-                                            {<text>There are @Model.TotalCount @moderationStatus Packages</text>}
-                                        }
-                                        @if (!moderationStatus.Equals("Unknown"))
-                                        {<text> in Moderation</text>}
-                                    </h3>
-                                    if (String.IsNullOrEmpty(Model.SearchTerm))
-                                    {
-                                        <form method="get" action="">
-                                            <fieldset class="form search mb-0">
-                                                <input type="hidden" name="q" value="@Model.SearchTerm" />
-                                                <input type="hidden" name="moderatorQueue" value="true" />
-                                                <button type="submit" name="moderationStatus" value="@Constants.UpdatedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationUpdatedPackageCount Updated</button>
-                                                <span>|</span>
-                                                <button type="submit" name="moderationStatus" value="@Constants.RespondedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationRespondedPackageCount Responded</button>
-                                                <span>|</span>
-                                                <button type="submit" name="moderationStatus" value="@Constants.SubmittedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationSubmittedPackageCount Submitted</button>
-                                                <span>|</span>
-                                                <button type="submit" name="moderationStatus" value="@Constants.WaitingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationWaitingPackageCount Waiting</button>
-                                                <span>|</span>
-                                                <button type="submit" name="moderationStatus" value="@Constants.ReadyModerationStatus" class="bg-transparent border-0 btn-link text-dark">@moderationReadyPackageCount Ready</button>
-                                                <span>|</span>
-                                                <button type="submit" name="moderationStatus" value="@Constants.PendingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationPendingAutoReviewPackageCount Pending</button>
-                                                <input type="hidden" name="prerelease" value="false" />
-                                                <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
-                                            </fieldset>
-                                        </form>
-                                    }
+                                {<text>There are @Model.TotalCount Community Maintained Packages</text>}
+                            </h3>
+                        }
+                        else
+                        {
+                            <h3 class="mb-0">
+                                @{
+                                    var moderationStatus = @Model.ModerationStatus.Remove(@Model.ModerationStatus.IndexOf("-")); // Get everything after -status
+                                    moderationStatus = char.ToUpper(moderationStatus.First()) + moderationStatus.Substring(1).ToLower(); // Capitalize first letter
                                 }
-                            }
-                            @if (@Model.TotalCount > 0 && (!moderationQueue || !Model.SearchTerm.IsEmpty()))
+                                @if (!String.IsNullOrEmpty(Model.SearchTerm))
+                                {
+                                    if (moderationStatus.Equals("All")){ moderationStatus = string.Empty; }
+                                    <text>Search for "@Model.SearchTerm" Returned @Model.TotalCount @moderationStatus Package</text>if(@Model.TotalCount != 1){<text>s</text>}
+                                }
+                                else if (moderationStatus.Equals("All")) {
+                                    if (@moderationCount == 1)
+                                    {<text>There is @moderationCount Package</text>}
+                                    else
+                                    {<text>There are @moderationCount Packages</text>}
+                                }
+                                else {
+                                    if (@Model.TotalCount == 1)
+                                    {<text>There is @Model.TotalCount @moderationStatus Package</text>}
+                                    else
+                                    {<text>There are @Model.TotalCount @moderationStatus Packages</text>}
+                                }
+                                @if (!moderationStatus.Equals("Unknown"))
+                                {<text> in Moderation</text>}
+                            </h3>
+                            if (String.IsNullOrEmpty(Model.SearchTerm))
                             {
-                                <p class="mb-0">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
-                            }
-                        </div>
-                        <div>
-                            @if (@Model.TotalCount > 0 && (moderationQueue && Model.SearchTerm.IsEmpty()))
-                            {
-                                <p class="mb-0 mb-lg-2">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
-                            }
-                            <button class="btn btn-primary my-2 mb-sm-0 mt-lg-0" data-toggle="modal" data-target="#package-preferences">Manage Package Preferences</button>
-                            <div class="modal fade" id="package-preferences" tabindex="-1" role="dialog" aria-labelledby="Manage Package Preferences" aria-hidden="true">
-                                <div class="modal-dialog" role="document">
-                                    <div class="modal-content">
-                                        <div class="modal-header">
-                                            <h4 class="mb-0">Manage Package Preferences</h4>
-                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                                <span aria-hidden="true" class="fas fa-times"></span>
-                                            </button>
-                                        </div>
-                                        <div class="modal-body">
-                                            <div class="custom-control custom-switch">
-                                                <input type="checkbox" class="custom-control-input" id="preferenceGridView">
-                                                <label class="custom-control-label" for="preferenceGridView">Make grid view your default view?</label>
-                                            </div>
-                                            @if (moderationRole)
-                                            {
-                                                <div class="custom-control custom-switch mt-3">
-                                                    <input type="checkbox" class="custom-control-input" id="preferenceModView">
-                                                    <label class="custom-control-label" for="preferenceModView">Make the Moderator Queue your default view?</label>
-                                                </div>
-                                            }
-                                        </div>
-                                        <div class="modal-footer text-right">
-                                            <button class="btn btn-success btn-preferences">Save Preferences</button>
-                                            <button class="btn btn-danger" data-dismiss="modal" aria-label="Close">Cancel</button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <hr class="d-none d-sm-block" />
-                    <nav class="navbar navbar-expand-sm p-0">
-                        <button class="btn btn-primary w-100 d-sm-none" type="button" data-toggle="collapse" data-target="#search-filters" aria-controls="search filters" aria-expanded="false" aria-label="Toggle Search Filters">View Search Filters</button>
-                        <div class="collapse navbar-collapse" id="search-filters">
-                            <div class="navbar-nav d-block w-100 mt-2 mt-sm-0">
                                 <form method="get" action="">
-                                    <fieldset class="form search">
+                                    <fieldset class="form search mb-0">
                                         <input type="hidden" name="q" value="@Model.SearchTerm" />
-                                        <div class="form-row align-items-center">
-                                            <div class="col-sm mb-2 mb-sm-0">
-                                                <select class="form-control" name="moderatorQueue" id="moderatorQueue" aria-label="Sort by Normal View or Moderator Queue">
-                                                    @ViewHelpers.Option("", "Normal View", Model.ModeratorQueue)
-                                                    @ViewHelpers.Option("true", "Moderator Queue", Model.ModeratorQueue)
-                                                </select>
-                                            </div>
-                                            <div class="col-sm mb-2 mb-sm-0 @if (!moderationQueue){<text>d-none</text>}">
-                                                <select class="form-control" name="moderationStatus" id="moderationStatus" aria-label="Moderation Sort Order">
-                                                    @ViewHelpers.Option(Constants.AllModerationStatuses, "All Moderation Statuses", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.SubmittedModerationStatus, "Submitted", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.UpdatedModerationStatus, "Updated", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.PendingModerationStatus, "Pending", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.WaitingModerationStatus, "Waiting", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.RespondedModerationStatus, "Responded", Model.ModerationStatus)
-                                                    @ViewHelpers.Option(Constants.ReadyModerationStatus, "Ready", Model.ModerationStatus)
-                                                </select>
-                                            </div>
-                                            <div class="col-sm mb-2 mb-sm-0">
-                                                <select class="form-control" name="prerelease" id="prerelease" aria-label="Sort by the inclusion of Prerelease Packages">
-                                                    @ViewHelpers.Option("false", "Stable Only", Model.IncludePrerelease)
-                                                    @ViewHelpers.Option("true", "Include Prerelease", Model.IncludePrerelease)
-                                                </select>
-                                            </div>
-                                            <div class="col-sm mb-2 mb-sm-0">
-                                                <select class="form-control" name="sortOrder" id="sortOrder" aria-label="Sort Order">
-                                                    @if (!Model.SearchTerm.IsEmpty())
-                                                    {
-                                                        @ViewHelpers.Option(Constants.RelevanceSortOrder, "Relevance", Model.SortOrder)
-                                                    }
-                                                    @ViewHelpers.Option(Constants.PopularitySortOrder, "Popularity", Model.SortOrder)
-                                                    @ViewHelpers.Option(Constants.AlphabeticSortOrder, "A-Z", Model.SortOrder)
-                                                    @ViewHelpers.Option(Constants.RecentSortOrder, "Recent", Model.SortOrder)
-                                                </select>
-                                            </div>
-                                            <div class="col-12 col-sm text-right">
-                                                <a href="@if(@FullHref.Contains("/packages")){<text>@Url.RouteUrl(RouteName.ListPackages)</text>}else{<text>@Url.RouteUrl(RouteName.SearchResults)</text>}" class="btn btn-outline-primary"><span class="fas fa-sync"></span><span class="d-sm-none d-md-inline-block ml-2 ml-sm-0 ml-md-2">Reset Filters</span></a>
-                                            </div>
-                                        </div>
+                                        <input type="hidden" name="moderatorQueue" value="true" />
+                                        <button type="submit" name="moderationStatus" value="@Constants.UpdatedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationUpdatedPackageCount Updated</button>
+                                        <span>|</span>
+                                        <button type="submit" name="moderationStatus" value="@Constants.RespondedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationRespondedPackageCount Responded</button>
+                                        <span>|</span>
+                                        <button type="submit" name="moderationStatus" value="@Constants.SubmittedModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationSubmittedPackageCount Submitted</button>
+                                        <span>|</span>
+                                        <button type="submit" name="moderationStatus" value="@Constants.WaitingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationWaitingPackageCount Waiting</button>
+                                        <span>|</span>
+                                        <button type="submit" name="moderationStatus" value="@Constants.ReadyModerationStatus" class="bg-transparent border-0 btn-link text-dark">@moderationReadyPackageCount Ready</button>
+                                        <span>|</span>
+                                        <button type="submit" name="moderationStatus" value="@Constants.PendingModerationStatus" class="bg-transparent border-0 btn-link text-dark">@Model.ModerationPendingAutoReviewPackageCount Pending</button>
+                                        <input type="hidden" name="prerelease" value="false" />
+                                        <input type="hidden" name="sortOrder" value="@Model.SortOrder" />
                                     </fieldset>
                                 </form>
+                            }
+                        }
+                    }
+                    @if (@Model.TotalCount > 0 && (!moderationQueue || !Model.SearchTerm.IsEmpty()))
+                    {
+                        <p class="mb-0">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
+                    }
+                </div>
+                <div>
+                    @if (@Model.TotalCount > 0 && (moderationQueue && Model.SearchTerm.IsEmpty()))
+                    {
+                        <p class="mb-0 mb-lg-2">Displaying Results @Model.FirstResultIndex - @Model.LastResultIndex of @Model.TotalCount</p>
+                    }
+                    <button class="btn btn-primary my-2 mb-sm-0 mt-lg-0" data-toggle="modal" data-target="#package-preferences">Manage Package Preferences</button>
+                    <div class="modal fade" id="package-preferences" tabindex="-1" role="dialog" aria-labelledby="Manage Package Preferences" aria-hidden="true">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h4 class="mb-0">Manage Package Preferences</h4>
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                        <span aria-hidden="true" class="fas fa-times"></span>
+                                    </button>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="custom-control custom-switch">
+                                        <input type="checkbox" class="custom-control-input" id="preferenceGridView">
+                                        <label class="custom-control-label" for="preferenceGridView">Make grid view your default view?</label>
+                                    </div>
+                                    @if (moderationRole)
+                                    {
+                                        <div class="custom-control custom-switch mt-3">
+                                            <input type="checkbox" class="custom-control-input" id="preferenceModView">
+                                            <label class="custom-control-label" for="preferenceModView">Make the Moderator Queue your default view?</label>
+                                        </div>
+                                    }
+                                </div>
+                                <div class="modal-footer text-right">
+                                    <button class="btn btn-success btn-preferences">Save Preferences</button>
+                                    <button class="btn btn-danger" data-dismiss="modal" aria-label="Close">Cancel</button>
+                                </div>
                             </div>
                         </div>
-                    </nav>
-                    @if (Request.Cookies["preferenceGridView"] != null)
-                    {
-                        <div class="row pt-3 package-grid-view">
-                            @foreach (var package in Model.Items)
-                            {
-                                <div class="col-lg-6 col-xl-4 mb-4">
-                                    <div class="card h-100">
-                                        @Html.Partial(MVC.Packages.Views._ListPackage, package)
+                    </div>
+                </div>
+            </div>
+            <hr class="d-none d-sm-block" />
+            <nav class="navbar navbar-expand-sm p-0">
+                <button class="btn btn-primary w-100 d-sm-none" type="button" data-toggle="collapse" data-target="#search-filters" aria-controls="search filters" aria-expanded="false" aria-label="Toggle Search Filters">View Search Filters</button>
+                <div class="collapse navbar-collapse" id="search-filters">
+                    <div class="navbar-nav d-block w-100 mt-2 mt-sm-0">
+                        <form method="get" action="">
+                            <fieldset class="form search">
+                                <input type="hidden" name="q" value="@Model.SearchTerm" />
+                                <div class="form-row align-items-center">
+                                    <div class="col-sm mb-2 mb-sm-0">
+                                        <select class="form-control" name="moderatorQueue" id="moderatorQueue" aria-label="Sort by Normal View or Moderator Queue">
+                                            @ViewHelpers.Option("", "Normal View", Model.ModeratorQueue)
+                                            @ViewHelpers.Option("true", "Moderator Queue", Model.ModeratorQueue)
+                                        </select>
+                                    </div>
+                                    <div class="col-sm mb-2 mb-sm-0 @if (!moderationQueue){<text>d-none</text>}">
+                                        <select class="form-control" name="moderationStatus" id="moderationStatus" aria-label="Moderation Sort Order">
+                                            @ViewHelpers.Option(Constants.AllModerationStatuses, "All Moderation Statuses", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.SubmittedModerationStatus, "Submitted", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.UpdatedModerationStatus, "Updated", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.PendingModerationStatus, "Pending", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.WaitingModerationStatus, "Waiting", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.RespondedModerationStatus, "Responded", Model.ModerationStatus)
+                                            @ViewHelpers.Option(Constants.ReadyModerationStatus, "Ready", Model.ModerationStatus)
+                                        </select>
+                                    </div>
+                                    <div class="col-sm mb-2 mb-sm-0">
+                                        <select class="form-control" name="prerelease" id="prerelease" aria-label="Sort by the inclusion of Prerelease Packages">
+                                            @ViewHelpers.Option("false", "Stable Only", Model.IncludePrerelease)
+                                            @ViewHelpers.Option("true", "Include Prerelease", Model.IncludePrerelease)
+                                        </select>
+                                    </div>
+                                    <div class="col-sm mb-2 mb-sm-0">
+                                        <select class="form-control" name="sortOrder" id="sortOrder" aria-label="Sort Order">
+                                            @if (!Model.SearchTerm.IsEmpty())
+                                            {
+                                                @ViewHelpers.Option(Constants.RelevanceSortOrder, "Relevance", Model.SortOrder)
+                                            }
+                                            @ViewHelpers.Option(Constants.PopularitySortOrder, "Popularity", Model.SortOrder)
+                                            @ViewHelpers.Option(Constants.AlphabeticSortOrder, "A-Z", Model.SortOrder)
+                                            @ViewHelpers.Option(Constants.RecentSortOrder, "Recent", Model.SortOrder)
+                                        </select>
+                                    </div>
+                                    <div class="col-12 col-sm text-right">
+                                        <a href="@if(@FullHref.Contains("/packages")){<text>@Url.RouteUrl(RouteName.ListPackages)</text>}else{<text>@Url.RouteUrl(RouteName.SearchResults)</text>}" class="btn btn-outline-primary"><span class="fas fa-sync"></span><span class="d-sm-none d-md-inline-block ml-2 ml-sm-0 ml-md-2">Reset Filters</span></a>
                                     </div>
                                 </div>
-                            }
+                            </fieldset>
+                        </form>
+                    </div>
+                </div>
+            </nav>
+            @if (Request.Cookies["preferenceGridView"] != null)
+            {
+                <div class="row pt-3 package-grid-view">
+                    @foreach (var package in Model.Items)
+                    {
+                        <div class="col-lg-6 col-xl-4 mb-4">
+                            <div class="card h-100">
+                                @Html.Partial(MVC.Packages.Views._ListPackage, package)
+                            </div>
                         </div>
                     }
-                    else
-                    {
-                        <ul class="list-unstyled pt-3 package-list-view">
-                            @foreach (var package in Model.Items)
-                            {
-                                <li>
-                                    @Html.Partial(MVC.Packages.Views._ListPackage, package)
-                                </li>
-                            }
-                        </ul>
-                    }
-
-                    @if (@FullHref.Contains("/packages"))
-                    {@ViewHelpers.PreviousNextPager(Model.Pager)}
-                    else
-                    {@ViewHelpers.PreviousNextPager(Model.PagerSearch)}
                 </div>
-                @if (!String.IsNullOrEmpty(Model.SearchTerm))
-                {
-                    <div class="tab-pane fade" id="documentation-results" role="tabpanel" aria-labelledby="documentation-tab">
-                        <h2 class="mb-lg-0">Search for "@Model.SearchTerm" Docs and Site Search Results</h2>
-                        <hr />
-                        <gcse:searchresults-only></gcse:searchresults-only>
-                    </div>
-                }
-            </div>
+            }
+            else
+            {
+                <ul class="list-unstyled pt-3 package-list-view">
+                    @foreach (var package in Model.Items)
+                    {
+                        <li>
+                            @Html.Partial(MVC.Packages.Views._ListPackage, package)
+                        </li>
+                    }
+                </ul>
+            }
+
+            @ViewHelpers.PreviousNextPager(Model.Pager)
         </div>
         <div class="d-none d-md-block col-md-4 col-xl-3 col-xxxl-2 border-left p-3">
             @Html.Partial("~/Views/Pages/_CollapsingRightSidebarContent.cshtml")

--- a/chocolatey/Website/Views/Shared/_SearchBox.cshtml
+++ b/chocolatey/Website/Views/Shared/_SearchBox.cshtml
@@ -1,19 +1,8 @@
 ﻿@using NuGetGallery
-@{
-    var pagePackages = ViewContext.RouteData.Values["Action"].Equals("ListPackages");
-    var searchAction = string.Empty;
-    if (pagePackages) {
-        searchAction =  @Url.PackageList();
-    }
-    else
-    {
-        searchAction = @Url.SearchResults();
-    }
-}
 
-<form class="form-inline search-box position-relative" autocomplete= "off" role="search" action="@searchAction" method="get">
+<form class="form-inline search-box position-relative" autocomplete= "off" role="search" action="@Url.PackageList()" method="get">
     <div class="input-group w-100">
-        <input class="form-control" name="q" type="text" title="Search" placeholder="Search @if(pagePackages){<text>Packages</text>}" value="@(String.IsNullOrEmpty(ViewBag.SearchTerm) ? "" : ViewBag.SearchTerm)" autofocus>
+        <input class="form-control" name="q" type="text" title="Search" placeholder="Search Packages" value="@(String.IsNullOrEmpty(ViewBag.SearchTerm) ? "" : ViewBag.SearchTerm)" autofocus>
         <div class="input-group-append">
             <button class="btn btn-light" type="submit" title="Search" value="">
                 <span class="fas fa-search" alt="Search"></span>


### PR DESCRIPTION
This removes the site results tab from the packages page. The search
now only shows package results. The Google Search js has also been
removed.

Fixes #1029 