### PR TITLE
Upgrade to .NET Framework 4.5.2

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -164,7 +164,6 @@ Task("Build")
         PlatformTarget = PlatformTarget.MSIL,
         Targets = { "Build" }
     }
-    .WithProperty("CodeAnalysis", "true")
     .WithProperty("OutDir", buildData.BuildArtifactsDirectoryPath.FullPath)
     );
 });

--- a/chocolatey/Website/Entities/Course.cs
+++ b/chocolatey/Website/Entities/Course.cs
@@ -1,15 +1,15 @@
-﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
 // authors/contributors from ChocolateyGallery
 // at https://github.com/chocolatey/chocolatey.org,
-// and the authors/contributors of NuGetGallery 
+// and the authors/contributors of NuGetGallery
 // at https://github.com/NuGet/NuGetGallery
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chocolatey/Website/Entities/Course.cs
+++ b/chocolatey/Website/Entities/Course.cs
@@ -17,8 +17,9 @@
 // limitations under the License.
 
 using System;
-using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGetGallery
 {
@@ -38,6 +39,7 @@ namespace NuGetGallery
         //public string CourseDescription { get; set; }
         //public int CourseModuleCount { get; set; }
 
+        [NotMapped]
         public CourseNameType CourseNameType { get; set; }
         [MaxLength(100)]
         [Column("CourseNameType")]

--- a/chocolatey/Website/Entities/CourseModule.cs
+++ b/chocolatey/Website/Entities/CourseModule.cs
@@ -1,15 +1,15 @@
-﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
 // authors/contributors from ChocolateyGallery
 // at https://github.com/chocolatey/chocolatey.org,
-// and the authors/contributors of NuGetGallery 
+// and the authors/contributors of NuGetGallery
 // at https://github.com/NuGet/NuGetGallery
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chocolatey/Website/Entities/CourseModule.cs
+++ b/chocolatey/Website/Entities/CourseModule.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGetGallery
 {
@@ -40,6 +41,7 @@ namespace NuGetGallery
         public int ModuleQuestionCount { get; set; }
         public int Order { get; set; }
 
+        [NotMapped]
         public CourseModuleNameType CourseModuleNameType { get; set; }
         [MaxLength(100)]
         [Column("CourseModuleNameType")]

--- a/chocolatey/Website/Entities/Package.cs
+++ b/chocolatey/Website/Entities/Package.cs
@@ -1,15 +1,15 @@
-﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original 
+﻿// Copyright 2011 - Present RealDimensions Software, LLC, the original
 // authors/contributors from ChocolateyGallery
 // at https://github.com/chocolatey/chocolatey.org,
-// and the authors/contributors of NuGetGallery 
+// and the authors/contributors of NuGetGallery
 // at https://github.com/NuGet/NuGetGallery
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/chocolatey/Website/Entities/Package.cs
+++ b/chocolatey/Website/Entities/Package.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGetGallery
 {
@@ -117,6 +118,7 @@ namespace NuGetGallery
 
         public bool Listed { get; set; }
 
+        [NotMapped]
         public PackageStatusType Status { get; set; }
         [MaxLength(100)]
         [Column("Status")]
@@ -130,6 +132,7 @@ namespace NuGetGallery
             }
         }
 
+        [NotMapped]
         public PackageSubmittedStatusType SubmittedStatus { get; set; }
         [MaxLength(50)]
         [Column("SubmittedStatus")]
@@ -156,6 +159,7 @@ namespace NuGetGallery
         /// </remarks>
         public string ReviewComments { get; set; }
 
+        [NotMapped]
         public PackageAutomatedReviewResultStatusType PackageTestResultStatus { get; set; }
         [MaxLength(50)]
         [Column("PackageTestResultStatus")]
@@ -173,6 +177,7 @@ namespace NuGetGallery
         public string PackageTestResultUrl { get; set; }
         public DateTime? PackageTestResultDate { get; set; }
 
+        [NotMapped]
         public PackageAutomatedReviewResultStatusType PackageValidationResultStatus { get; set; }
         [MaxLength(50)]
         [Column("PackageValidationResultStatus")]
@@ -189,6 +194,7 @@ namespace NuGetGallery
 
         public DateTime? PackageCleanupResultDate { get; set; }
 
+        [NotMapped]
         public PackageDownloadCacheStatusType DownloadCacheStatus { get; set; }
         [MaxLength(50)]
         [Column("DownloadCacheStatus")]
@@ -207,6 +213,7 @@ namespace NuGetGallery
         /// </remarks>
         public string DownloadCache { get; set; }
 
+        [NotMapped]
         public PackageScanStatusType PackageScanStatus { get; set; }
         [MaxLength(50)]
         [Column("PackageScanStatus")]

--- a/chocolatey/Website/Entities/PackageFramework.cs
+++ b/chocolatey/Website/Entities/PackageFramework.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Versioning;
 using NuGet;
 

--- a/chocolatey/Website/Entities/PackageFramework.cs
+++ b/chocolatey/Website/Entities/PackageFramework.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
 
         public Package Package { get; set; }
         //public int PackageKey { get; set; }
-        
+
         [StringLength(256)]
         public string TargetFramework
         {

--- a/chocolatey/Website/RequestModels/RegisterRequest.cs
+++ b/chocolatey/Website/RequestModels/RegisterRequest.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
 
         [AllowHtml]
         [Required]
-        [Compare("Password")]
+        [System.ComponentModel.DataAnnotations.Compare("Password")]
         [DataType(DataType.Password)]
         [StringLength(64, MinimumLength = 7)]
         [Display(Name = "Password Confirmation")]

--- a/chocolatey/Website/Services/PackageService.cs
+++ b/chocolatey/Website/Services/PackageService.cs
@@ -122,7 +122,7 @@ namespace NuGetGallery
 
             Trace.TraceInformation("[{0}] - Backgrounding the update and notify on package submission.".format_with(requestInformation));
             // Run the following without stopping grabbing the item
-            TaskEx.Run(() =>
+            Task.Run(() =>
             {
                 Trace.TraceInformation("[{0}] - Starting Update and Notify.".format_with(requestInformation));
                 InvalidateAndRegeneratePackageCaches(package.PackageRegistration.Id, package.Version, package.IconUrl, package.Key, package.PackageRegistration.Key, requestInformation);
@@ -1267,18 +1267,18 @@ namespace NuGetGallery
         //private void NotifyIndexingService()
         //{
         //    // run on background thread
-        //    TaskEx.Run(() => indexingSvc.UpdateIndex(forceRefresh:false));
+        //    Task.Run(() => indexingSvc.UpdateIndex(forceRefresh:false));
         //}
 
         private void NotifyIndexingService(Package package)
         {
             // run on background thread
-            TaskEx.Run(() => indexingSvc.UpdatePackage(package));
+            Task.Run(() => indexingSvc.UpdatePackage(package));
         }
 
         private void InvalidateCache(string packageRegistrationId, int packageRegistrationKey)
         {
-            TaskEx.Run(
+            Task.Run(
                 () =>
                 {
                     Cache.InvalidateCacheItem(string.Format("packageregistration-{0}", packageRegistrationId.to_lower()));
@@ -1295,7 +1295,7 @@ namespace NuGetGallery
 
         private void NotifyForModeration(Package package, string comments)
         {
-            TaskEx.Run(() => messageSvc.SendPackageModerationEmail(package, comments, Constants.MODERATION_SUBMITTED, null));
+            Task.Run(() => messageSvc.SendPackageModerationEmail(package, comments, Constants.MODERATION_SUBMITTED, null));
         }
     }
 }

--- a/chocolatey/Website/ViewModels/PasswordResetViewModel.cs
+++ b/chocolatey/Website/ViewModels/PasswordResetViewModel.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery
         [Required]
         [DataType(DataType.Password)]
         [Display(Name = "Confirm new password")]
-        [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
+        [System.ComponentModel.DataAnnotations.Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
     }
 }

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -196,7 +196,7 @@
     </system.webServer>
   </location>
   <system.web>
-    <compilation debug="true" targetFramework="4.0">
+    <compilation debug="true" targetFramework="4.5.2">
       <assemblies>
         <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
         <add assembly="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
@@ -208,7 +208,7 @@
     <authentication mode="Forms">
       <forms name=".ChocolateyGalleryAuthentication" loginUrl="~/Users/Account/LogOn" timeout="4320" slidingExpiration="true" cookieless="UseCookies" />
     </authentication>
-    <pages>
+    <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
         <add namespace="System.Web.Helpers" />
         <add namespace="System.Web.Mvc" />
@@ -354,7 +354,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/chocolatey/Website/Web.config
+++ b/chocolatey/Website/Web.config
@@ -54,7 +54,6 @@
     <add key="Gallery:SmtpUsername" value="" />
     <add key="Gallery:SmtpPassword" value="" />
     <add key="Gallery:SmtpEnableSsl" value="false" />
-
     <add key="Gallery:ModeratorEmail" value="nobody@nowhere.com" />
     <add key="Gallery:ContactUsEmail" value="nobody@nowhere.com" />
     <add key="Gallery:PackageFileTextExtensions" value="ps1,psm1,psd1,txt,md,cmd,config,conf,bat,sh,json,js,xml,xdt,ini,iss,ahk,au3,sql,conf,vbs,inf,nuspec,template,reg,cs,manifest,csv,py,rb" />
@@ -66,16 +65,13 @@
     <add key="Gallery:ScanResultsKey" value="12345" />
     <add key="Gallery:IndexContainsAllVersions" value="true" />
     <add key="Gallery:StudentDiscount" value="https://somewhere.com" />
-    
     <add key="Gallery:UseBackgroundJobsDatabaseUser" value="false" />
     <add key="Gallery:BackgroundJobsDatabaseUserId" value="" />
     <add key="Gallery:BackgroundJobsDatabaseUserPassword" value="" />
-
     <add key="ForceSSL" value="false" />
     <add key="DisqusShortname" value="chocolatey-local" />
     <add key="EnablePackageStatisticsBackgroundJob" value="false" />
     <add key="EnableWorkItemsBackgroundJob" value="false" />
-
     <add key="Enyim.Caching.Diagnostics.LogPath" value="c:\enyimcaching.log" />
     <add key="Cache.IsCacheEnabled" value="true" />
     <add key="Cache.IsCacheDependencyManagementEnabled" value="false" />

--- a/chocolatey/Website/Website.csproj
+++ b/chocolatey/Website/Website.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGetGallery</RootNamespace>
     <AssemblyName>NuGetGallery.Website</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <MvcBuildViews>true</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -32,6 +32,9 @@
     <IISExpressUseClassicPipelineMode />
     <Use64BitIISExpress />
     <UseGlobalApplicationHostFile />
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,6 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -50,6 +54,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AjaxMin">
@@ -87,9 +92,9 @@
     <Reference Include="Elmah.Contrib.Mvc">
       <HintPath>..\..\packages\Elmah.Contrib.Mvc.1.0\lib\net40\Elmah.Contrib.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+    <Reference Include="EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\EntityFramework.4.3.1\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\..\packages\EntityFramework.5.0.0\lib\net45\EntityFramework.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Enyim.Caching">
@@ -110,7 +115,7 @@
       <HintPath>..\..\packages\ImageResizer.3.4.3\lib\ImageResizer.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Lucene.Net">
@@ -232,27 +237,18 @@
       <HintPath>..\..\packages\SimpleInjector.Integration.Web.Mvc.2.0.0\lib\net40\SimpleInjector.Integration.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis">
-      <HintPath>..\..\packages\StackExchange.Redis.1.0.371\lib\net40\StackExchange.Redis.dll</HintPath>
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.371\lib\net45\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Data.Services" />
     <Reference Include="System.Data.Services.Client" />
-    <Reference Include="System.IO">
-      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Spatial">
       <HintPath>..\..\packages\System.Spatial.5.0.1\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/chocolatey/Website/packages.config
+++ b/chocolatey/Website/packages.config
@@ -1,60 +1,60 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net40" />
-  <package id="AnglicanGeek.MarkdownMailer" version="1.2" />
-  <package id="AnglicanGeek.WindowsAzure.ServiceRuntime" version="1.6" />
-  <package id="AspNetMvc" version="3.0.20105.0" />
-  <package id="AspNetRazor.Core" version="1.0.20105.407" />
-  <package id="AspNetWebPages.Core" version="1.0.20105.407" />
+  <package id="AnglicanGeek.MarkdownMailer" version="1.2" targetFramework="net452" />
+  <package id="AnglicanGeek.WindowsAzure.ServiceRuntime" version="1.6" targetFramework="net452" />
+  <package id="AspNetMvc" version="3.0.20105.0" targetFramework="net452" />
+  <package id="AspNetRazor.Core" version="1.0.20105.407" targetFramework="net452" />
+  <package id="AspNetWebPages.Core" version="1.0.20105.407" targetFramework="net452" />
   <package id="AWSSDK" version="1.3.18.0" />
   <package id="Cassette" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Aspnet" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.MSBuild" version="2.4.2" targetFramework="net40" />
   <package id="Cassette.Views" version="2.4.2" targetFramework="net40" />
   <package id="elmah" version="1.2.0.1" />
-  <package id="Elmah.Contrib.Mvc" version="1.0" />
+  <package id="Elmah.Contrib.Mvc" version="1.0" targetFramework="net452" />
   <package id="elmah.corelibrary" version="1.2" />
   <package id="elmah.sqlserver" version="1.2" />
-  <package id="EntityFramework" version="4.3.1" />
+  <package id="EntityFramework" version="5.0.0" targetFramework="net452" />
   <package id="EnyimMemcached" version="2.13" targetFramework="net40" />
-  <package id="EnyimMemcached-log4net" version="2.13" targetFramework="net40" />
+  <package id="EnyimMemcached-log4net" version="2.13" targetFramework="net452" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net40" />
   <package id="jQuery" version="3.3.1" targetFramework="net40" />
   <package id="jQuery.Validation" version="1.8.1" />
-  <package id="log4net" version="2.0.5" targetFramework="net40" />
+  <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net40" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net40" />
   <package id="Markdig" version="0.18.0" targetFramework="net40" />
   <package id="MarkdownSharp" version="2.0.5" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net452" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Microsoft.Data.Edm" version="5.0.1" targetFramework="net40" />
   <package id="Microsoft.Data.OData" version="5.0.1" targetFramework="net40" />
   <package id="Microsoft.Data.OData.Contrib" version="5.0.1.50822" targetFramework="net40" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="microsoft-web-helpers" version="1.15" />
-  <package id="MiniProfiler" version="2.0.0-rc1" />
-  <package id="MiniProfiler.EF" version="2.0.1-rc1" />
-  <package id="MiniProfiler.MVC3" version="1.9.1" />
+  <package id="MiniProfiler" version="2.0.0-rc1" targetFramework="net452" />
+  <package id="MiniProfiler.EF" version="2.0.1-rc1" targetFramework="net452" />
+  <package id="MiniProfiler.MVC3" version="1.9.1" targetFramework="net452" />
   <package id="Modernizr" version="2.0.6" />
-  <package id="MvcHaack.Ajax" version="1.1" />
-  <package id="Newtonsoft.Json" version="4.5.6" />
+  <package id="MvcHaack.Ajax" version="1.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net452" />
   <package id="Nuget.Core" version="2.1.0-alpha001" targetFramework="net40" />
-  <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" />
-  <package id="QueryInterceptor" version="0.1.4237.2400" />
-  <package id="RouteMagic" version="1.1.3" />
+  <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" targetFramework="net452" />
+  <package id="QueryInterceptor" version="0.1.4237.2400" targetFramework="net452" />
+  <package id="RouteMagic" version="1.1.3" targetFramework="net452" />
   <package id="ServerAppFabric.Client" version="1.1.2106" targetFramework="net40" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />
   <package id="SimpleInjector" version="2.0.0" targetFramework="net40" />
-  <package id="SimpleInjector.Integration.Web" version="2.0.0" targetFramework="net40" />
-  <package id="SimpleInjector.Integration.Web.Mvc" version="2.0.0" targetFramework="net40" />
-  <package id="SimpleInjector.MVC3" version="2.0.0" targetFramework="net40" />
-  <package id="StackExchange.Redis" version="1.0.371" targetFramework="net40" />
+  <package id="SimpleInjector.Integration.Web" version="2.0.0" targetFramework="net452" />
+  <package id="SimpleInjector.Integration.Web.Mvc" version="2.0.0" targetFramework="net452" />
+  <package id="SimpleInjector.MVC3" version="2.0.0" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.0.371" targetFramework="net452" />
   <package id="System.Spatial" version="5.0.1" targetFramework="net40" />
   <package id="T4MVC" version="2.6.64" />
-  <package id="WebActivator" version="1.4.4" />
+  <package id="WebActivator" version="1.4.4" targetFramework="net452" />
   <package id="WebBackgrounder" version="0.2.0" targetFramework="net40" />
-  <package id="WebBackgrounder.EntityFramework" version="0.1" />
-  <package id="WindowsAzure.Storage" version="1.6" />
+  <package id="WebBackgrounder.EntityFramework" version="0.1" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="1.6" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
In order to accomplish this, it was necessary to upgrade EntityFramework
package to 5.0.0.  This was due to the fact that some attributes that
are being used on the entity classes have moved to a new namespace.
The necessary attribute changes have been made.

In addition, it was necessary to add the NotMapped attribute to a number
of properties, otherwise EF was changing that a migration was required
to be added.  My assumption here is that in EF 5.0.0 there has been a
change in how mapped properties were discovered. In EF 4.3.1 the
NotMapped attribute was not required, but now it is.

Where necessary, NuGet packages were uninstalled and re-installed in
order to re-target to .NET Framework 4.5.2.

Fixes #1039 

I am going to put this up on the Test Site, and I will comment on this PR when this is live.